### PR TITLE
Add new ticket fields and rewrite FullString() to YAML-frontmatter format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/spf13/cobra v1.10.2
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -97,4 +97,7 @@ golang.org/x/term v0.31.0 h1:erwDkOK1Msy6offm1mOgvspSkslFnIGsFnxOKoufg3o=
 golang.org/x/term v0.31.0/go.mod h1:R4BeIy7D95HzImkxGkTW1UQTtP54tio2RyHz7PwK0aw=
 golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=
 golang.org/x/text v0.24.0/go.mod h1:L8rBsPeo2pSS+xqN0d5u2ikmjtmoJbDBT1b7nHvFCdU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/tickets/ticket.go
+++ b/internal/tickets/ticket.go
@@ -1,12 +1,43 @@
 package tickets
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
 
 // Ticket represents a single ticket.
 type Ticket struct {
 	Title       string
 	ID          string
 	Description string
+	Status      string
+	Type        string
+	Priority    int
+	Assignee    string
+	Created     string
+	Parent      string
+	ExternalRef string
+	Deps        []string
+	Links       []string
+	Tags        []string
+}
+
+// frontmatter is a helper struct for YAML marshaling of ticket metadata.
+// It excludes Title and Description which are rendered outside the frontmatter.
+type frontmatter struct {
+	ID          string   `yaml:"id"`
+	Status      string   `yaml:"status,omitempty"`
+	Type        string   `yaml:"type,omitempty"`
+	Priority    int      `yaml:"priority,omitempty"`
+	Assignee    string   `yaml:"assignee,omitempty"`
+	Created     string   `yaml:"created,omitempty"`
+	Parent      string   `yaml:"parent,omitempty"`
+	ExternalRef string   `yaml:"external_ref,omitempty"`
+	Deps        []string `yaml:"deps,omitempty"`
+	Links       []string `yaml:"links,omitempty"`
+	Tags        []string `yaml:"tags,omitempty"`
 }
 
 // String returns a formatted single-line representation: "ID Title"
@@ -14,11 +45,44 @@ func (t *Ticket) String() string {
 	return fmt.Sprintf("%s %s", t.ID, t.Title)
 }
 
-// FullString returns the full markdown representation of a ticket.
+// FullString returns the full markdown representation of a ticket
+// in YAML-frontmatter-first format.
 func (t *Ticket) FullString() string {
-	s := fmt.Sprintf("# %s\n---\nid: %s\n---\n", t.Title, t.ID)
-	if t.Description != "" {
-		s += t.Description + "\n"
+	fm := frontmatter{
+		ID:          t.ID,
+		Status:      t.Status,
+		Type:        t.Type,
+		Priority:    t.Priority,
+		Assignee:    t.Assignee,
+		Created:     t.Created,
+		Parent:      t.Parent,
+		ExternalRef: t.ExternalRef,
+		Deps:        t.Deps,
+		Links:       t.Links,
+		Tags:        t.Tags,
 	}
-	return s
+
+	yamlBytes, err := yaml.Marshal(fm)
+	if err != nil {
+		// Fallback: should never happen with simple types
+		yamlBytes = []byte(fmt.Sprintf("id: %s\n", t.ID))
+	}
+
+	// yaml.Marshal adds a trailing newline; trim it since we add our own
+	yamlStr := strings.TrimRight(string(yamlBytes), "\n")
+
+	var b strings.Builder
+	b.WriteString("---\n")
+	b.WriteString(yamlStr)
+	b.WriteString("\n---\n")
+	b.WriteString("# ")
+	b.WriteString(t.Title)
+	b.WriteString("\n")
+
+	if t.Description != "" {
+		b.WriteString(t.Description)
+		b.WriteString("\n")
+	}
+
+	return b.String()
 }

--- a/internal/tickets/ticket_test.go
+++ b/internal/tickets/ticket_test.go
@@ -1,0 +1,250 @@
+package tickets
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFullStringMinimal(t *testing.T) {
+	ticket := &Ticket{
+		Title: "Fix login bug",
+		ID:    "abc",
+	}
+
+	got := ticket.FullString()
+	want := "---\nid: abc\n---\n# Fix login bug\n"
+
+	if got != want {
+		t.Errorf("FullString() =\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestFullStringWithDescription(t *testing.T) {
+	ticket := &Ticket{
+		Title:       "Fix login bug",
+		ID:          "abc",
+		Description: "The login page crashes on submit.",
+	}
+
+	got := ticket.FullString()
+	want := "---\nid: abc\n---\n# Fix login bug\nThe login page crashes on submit.\n"
+
+	if got != want {
+		t.Errorf("FullString() =\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestFullStringWithAllFields(t *testing.T) {
+	ticket := &Ticket{
+		Title:       "Big feature",
+		ID:          "XyZ",
+		Description: "Implement the thing.",
+		Status:      "open",
+		Type:        "feature",
+		Priority:    3,
+		Assignee:    "alice",
+		Created:     "2026-01-15",
+		Parent:      "prt",
+		ExternalRef: "JIRA-123",
+		Deps:        []string{"dep1", "dep2"},
+		Links:       []string{"lnk1"},
+		Tags:        []string{"backend", "urgent"},
+	}
+
+	got := ticket.FullString()
+
+	// Verify structure
+	if !strings.HasPrefix(got, "---\n") {
+		t.Error("should start with ---")
+	}
+
+	// Check all fields are present
+	checks := []string{
+		"id: XyZ",
+		"status: open",
+		"type: feature",
+		"priority: 3",
+		"assignee: alice",
+		"created: \"2026-01-15\"",
+		"parent: prt",
+		"external_ref: JIRA-123",
+		"deps:",
+		"- dep1",
+		"- dep2",
+		"links:",
+		"- lnk1",
+		"tags:",
+		"- backend",
+		"- urgent",
+		"# Big feature",
+		"Implement the thing.",
+	}
+
+	for _, check := range checks {
+		if !strings.Contains(got, check) {
+			t.Errorf("FullString() missing %q\ngot:\n%s", check, got)
+		}
+	}
+
+	// Verify title comes after second ---
+	parts := strings.SplitN(got, "---\n", 3)
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 parts split by ---, got %d", len(parts))
+	}
+	if !strings.HasPrefix(parts[2], "# Big feature\n") {
+		t.Errorf("title should be first line after frontmatter, got:\n%s", parts[2])
+	}
+}
+
+func TestFullStringWithArrays(t *testing.T) {
+	ticket := &Ticket{
+		Title: "Array test",
+		ID:    "arr",
+		Deps:  []string{"a", "b", "c"},
+		Tags:  []string{"tag1"},
+	}
+
+	got := ticket.FullString()
+
+	if !strings.Contains(got, "deps:\n    - a\n    - b\n    - c") {
+		t.Errorf("FullString() deps format unexpected:\n%s", got)
+	}
+	if !strings.Contains(got, "tags:\n    - tag1") {
+		t.Errorf("FullString() tags format unexpected:\n%s", got)
+	}
+}
+
+func TestFullStringEmptyArrays(t *testing.T) {
+	ticket := &Ticket{
+		Title: "Empty arrays",
+		ID:    "emp",
+		Deps:  []string{},
+		Links: []string{},
+		Tags:  []string{},
+	}
+
+	got := ticket.FullString()
+
+	// Empty slices should be omitted by omitempty
+	if strings.Contains(got, "deps:") {
+		t.Error("empty deps should be omitted")
+	}
+	if strings.Contains(got, "links:") {
+		t.Error("empty links should be omitted")
+	}
+	if strings.Contains(got, "tags:") {
+		t.Error("empty tags should be omitted")
+	}
+}
+
+func TestFullStringNilArrays(t *testing.T) {
+	ticket := &Ticket{
+		Title: "Nil arrays",
+		ID:    "nil",
+	}
+
+	got := ticket.FullString()
+
+	if strings.Contains(got, "deps:") {
+		t.Error("nil deps should be omitted")
+	}
+	if strings.Contains(got, "links:") {
+		t.Error("nil links should be omitted")
+	}
+	if strings.Contains(got, "tags:") {
+		t.Error("nil tags should be omitted")
+	}
+}
+
+func TestFullStringPriorityZero(t *testing.T) {
+	ticket := &Ticket{
+		Title:    "Priority zero",
+		ID:       "pz0",
+		Priority: 0,
+	}
+
+	got := ticket.FullString()
+
+	// Priority 0 is omitted by omitempty (acceptable per plan)
+	if strings.Contains(got, "priority:") {
+		t.Error("priority 0 should be omitted by omitempty")
+	}
+}
+
+func TestFullStringPriorityNonZero(t *testing.T) {
+	ticket := &Ticket{
+		Title:    "Priority two",
+		ID:       "pt2",
+		Priority: 2,
+	}
+
+	got := ticket.FullString()
+
+	if !strings.Contains(got, "priority: 2") {
+		t.Errorf("should contain priority: 2, got:\n%s", got)
+	}
+}
+
+func TestFullStringOmitsEmptyStrings(t *testing.T) {
+	ticket := &Ticket{
+		Title: "Minimal",
+		ID:    "min",
+	}
+
+	got := ticket.FullString()
+
+	omitted := []string{"status:", "type:", "assignee:", "created:", "parent:", "external_ref:"}
+	for _, field := range omitted {
+		if strings.Contains(got, field) {
+			t.Errorf("empty field %q should be omitted, got:\n%s", field, got)
+		}
+	}
+}
+
+func TestFullStringMultilineDescription(t *testing.T) {
+	ticket := &Ticket{
+		Title:       "Multiline",
+		ID:          "mlt",
+		Description: "Line one.\n\nLine three.\n\n```go\nfmt.Println(\"hello\")\n```",
+	}
+
+	got := ticket.FullString()
+
+	if !strings.Contains(got, "Line one.\n\nLine three.") {
+		t.Error("multiline description not preserved")
+	}
+	if !strings.Contains(got, "```go\nfmt.Println(\"hello\")\n```") {
+		t.Error("code block in description not preserved")
+	}
+}
+
+func TestString(t *testing.T) {
+	ticket := &Ticket{
+		Title: "My ticket",
+		ID:    "abc",
+	}
+
+	got := ticket.String()
+	want := "abc My ticket"
+
+	if got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}
+
+func TestStringIgnoresOtherFields(t *testing.T) {
+	ticket := &Ticket{
+		Title:       "My ticket",
+		ID:          "abc",
+		Description: "Some desc",
+		Status:      "open",
+		Priority:    3,
+	}
+
+	got := ticket.String()
+	want := "abc My ticket"
+
+	if got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Extend the Ticket struct with new fields and rewrite `FullString()` to output YAML-frontmatter-first format, replacing the old title-first format. This is the first step in a multi-step migration to a richer ticket format.

- Add 10 new fields to `Ticket` struct: Status, Type, Priority (int), Assignee, Created, Parent, ExternalRef (string), Deps, Links, Tags ([]string)
- Add `frontmatter` helper struct with YAML tags for marshaling (excludes Title and Description)
- Use `gopkg.in/yaml.v3` for proper YAML serialization
- All fields except `id` use `omitempty` to keep output minimal
- Rewrite `FullString()` to output `---\nYAML\n---\n# Title\nDescription` format
- `String()` method unchanged (still returns `"ID Title"`)
- Add 12 unit tests in `ticket_test.go` covering minimal, full, array, and edge cases