### PR TITLE
Simplify file naming to <id>.md and rewrite parseFile() for YAML frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Breaking:** Tickets now stored as individual files in `docs/tickets/` directory
-  - Each ticket is a separate file named `<id>-<slug>.md`
-  - File format uses `# Title` heading (was `## Title` in TODO.md)
+  - Each ticket is a separate file named `<id>.md`
+  - File format uses YAML frontmatter (`---` delimited) followed by `# Title` heading and description
   - Enables better git diffs and easier manual editing
 - All commands now reference tickets by ID only, not by title
   - Affects: `show`, `done`, `set-description`

--- a/README.md
+++ b/README.md
@@ -100,26 +100,26 @@ Opens an interactive prompt to quickly add a ticket and exit.
 
 ## File Format
 
-Tickets are stored in a `docs/tickets/` directory, one file per ticket. Each file is named `<id>-<slug>.md`:
+Tickets are stored in a `docs/tickets/` directory, one file per ticket. Each file is named `<id>.md`:
 
 ```
 docs/tickets/
-├── aBc-fix-login-timeout.md
-└── xYz-refactor-auth-module.md
+├── aBc.md
+└── xYz.md
 ```
 
-Each file contains:
+Each file contains YAML frontmatter followed by the title and optional description:
 
 ```markdown
-# Fix login timeout
 ---
 id: aBc
 ---
+# Fix login timeout
 Description goes here.
 Multiple lines are supported.
 ```
 
-The `#` heading is the ticket title. A YAML front matter block (`---` delimited) contains the `id`. Everything after the closing `---` is the description.
+The YAML frontmatter block (`---` delimited) contains the ticket metadata. The `id` field is always present; additional fields like `status`, `type`, `priority`, `assignee`, `tags`, etc. are included only when set. The `# Title` heading follows the frontmatter. Everything after the title line is the description.
 
 ## License
 


### PR DESCRIPTION
Simplifies ticket file naming from `<id>-<slug>.md` to `<id>.md` and rewrites `parseFile()` to read the YAML-frontmatter-first format introduced in PR #2.

### Changes

- **Removed `slugify()` function** and its `regexp`/`bufio` imports — no longer needed since filenames are just `<id>.md`
- **Simplified `ticketFileName(id)`** to single argument, returns `<id>.md`
- **Simplified `ticketFilePath(dir, id)`** — removed title parameter
- **Rewrote `findTicketFile()`** — uses exact `os.Stat()` check instead of glob pattern
- **Rewrote `parseFile()`** — parses YAML frontmatter (`---` delimited) using `gopkg.in/yaml.v3`, extracts `# Title` heading, and populates all 13 Ticket fields
- **Simplified `SetDescription()`** — overwrites file in place (no rename needed since filename doesn't depend on title)
- **Updated `file_test.go`** — removed `TestSlugify`, rewrote `TestTicketFileName`/`TestFileFormat`/`TestDone`, added `TestParseFileRoundTripAllFields` (13-field round-trip) and `TestParseFileDescriptionWithDashes`
- **Updated `README.md`** — file format section reflects `<id>.md` naming and YAML-frontmatter-first content
- **Updated `CHANGELOG.md`** — breaking change description updated

All 32 unit tests and 29 bats integration tests pass.
