### PR TITLE
Change Done() to set status=closed instead of deleting ticket files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Each ticket is a separate file named `<id>.md`
   - File format uses YAML frontmatter (`---` delimited) followed by `# Title` heading and description
   - Enables better git diffs and easier manual editing
+- `todo done` now sets `status: closed` instead of deleting the ticket file. Closed tickets are preserved on disk but hidden from `list` and TUI.
 - All commands now reference tickets by ID only, not by title
   - Affects: `show`, `done`, `set-description`
   - Title fallback removed from internal lookup functions

--- a/README.md
+++ b/README.md
@@ -82,13 +82,15 @@ EOF
 todo done aBc
 ```
 
+This sets the ticket's status to `closed`. The ticket file is preserved on disk but hidden from `list` and the TUI. Use `show` to view closed tickets.
+
 ### Interactive TUI
 
 ```bash
 todo tui
 ```
 
-Launches a full-screen terminal interface with a split-panel layout (ticket list + detail view). Navigate, add, and delete tickets interactively.
+Launches a full-screen terminal interface with a split-panel layout (ticket list + detail view). Navigate, add, and close tickets interactively.
 
 ### Quick add (for tmux popups)
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -19,9 +19,17 @@ var listCmd = &cobra.Command{
 			return err
 		}
 
-		items, err := tickets.List(dir)
+		allItems, err := tickets.List(dir)
 		if err != nil {
 			return err
+		}
+
+		// Filter out closed tickets
+		var items []*tickets.Ticket
+		for _, t := range allItems {
+			if t.Status != "closed" {
+				items = append(items, t)
+			}
 		}
 
 		if len(items) == 0 {

--- a/internal/tickets/file.go
+++ b/internal/tickets/file.go
@@ -205,7 +205,7 @@ func Show(dir string, id string) (*Ticket, error) {
 	return parseFile(path)
 }
 
-// Done removes a ticket by ID.
+// Done marks a ticket as closed by setting its status.
 func Done(dir string, id string) (string, error) {
 	path, err := findTicketFile(dir, id)
 	if err != nil {
@@ -217,7 +217,9 @@ func Done(dir string, id string) (string, error) {
 		return "", err
 	}
 
-	if err := os.Remove(path); err != nil {
+	t.Status = "closed"
+
+	if err := writeFile(dir, t); err != nil {
 		return "", err
 	}
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -84,7 +84,14 @@ func tickCmd() tea.Cmd {
 
 func (m Model) loadTickets() tea.Cmd {
 	return func() tea.Msg {
-		items, _ := tickets.List(m.dir)
+		allItems, _ := tickets.List(m.dir)
+		// Filter out closed tickets
+		var items []*tickets.Ticket
+		for _, t := range allItems {
+			if t.Status != "closed" {
+				items = append(items, t)
+			}
+		}
 		return ticketsLoadedMsg{items: items}
 	}
 }

--- a/test/done.bats
+++ b/test/done.bats
@@ -2,7 +2,7 @@
 
 load test_helper
 
-@test "done: removes ticket" {
+@test "done: closes ticket" {
   local out
   out="$(todo add "To be done")"
   local id
@@ -12,6 +12,11 @@ load test_helper
   assert_success
   assert_output --partial "Completed ticket"
   assert_output --partial "To be done"
+
+  # Ticket should have status: closed
+  run todo show "${id}"
+  assert_success
+  assert_output --partial "status: closed"
 
   # Ticket should no longer appear in list
   run todo list
@@ -24,7 +29,7 @@ load test_helper
   assert_output --partial "ticket not found"
 }
 
-@test "done: only removes the targeted ticket" {
+@test "done: only closes the targeted ticket" {
   local out1 out2
   out1="$(todo add "Keep me")"
   out2="$(todo add "Remove me")"
@@ -39,7 +44,7 @@ load test_helper
   refute_output --partial "Remove me"
 }
 
-@test "done: reduces ticket count by one" {
+@test "done: reduces visible ticket count by one" {
   todo add "One"
   local out
   out="$(todo add "Two")"
@@ -52,4 +57,16 @@ load test_helper
   todo done "${id}"
 
   [[ "$(ticket_count)" -eq 2 ]]
+}
+
+@test "done: ticket file still exists after close" {
+  local out
+  out="$(todo add "Persisted")"
+  local id
+  id="$(echo "${out}" | awk '{print $2}')"
+
+  todo done "${id}"
+
+  # File should still be on disk
+  [[ -f "docs/tickets/${id}.md" ]]
 }


### PR DESCRIPTION
Changes `Done()` from deleting ticket files to setting `status: closed` and writing them back to disk. Closed tickets are preserved on disk but filtered from `list` and TUI views, while `show` still works on them.

- `internal/tickets/file.go`: `Done()` now sets `t.Status = "closed"` and calls `writeFile()` instead of `os.Remove()`
- `cmd/list.go`: Filters out tickets with `Status == "closed"` before display
- `internal/tui/tui.go`: Filters closed tickets in `loadTickets()`
- `internal/tickets/file_test.go`: Updated `TestDone` (verifies file persists with status=closed) and `TestMultipleTickets` (verifies closed ticket included in `List()` count)
- `test/done.bats`: Rewrote tests for close behavior, added "ticket file still exists after close" test (30 bats tests total)
- `README.md`: Updated "Complete a ticket" section and TUI description
- `CHANGELOG.md`: Added unreleased entry for the behavior change