### PR TITLE
Add creation flags to add command with defaults and validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Render markdown in TUI detail panel using glamour
 - Comprehensive bats integration tests
 - Space shortcut in TUI to copy ticket ID to clipboard
+- `todo add` flags: `-d/--description`, `-t/--type` (default `task`), `-p/--priority` (default `2`), `-a/--assignee` (default `git user.name`), `--external-ref`, `--parent` (validates existence), `--design`, `--acceptance`, `--tags` (comma-separated)
+- Default title "Untitled" when `todo add` is called with no arguments
+- Parent ticket validation: `--parent` must reference an existing ticket ID
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,14 @@ make install  # go install
 ### Add a ticket
 
 ````bash
-# Simple ticket
+# Simple ticket (defaults: type=task, priority=2, assignee=git user.name)
 todo add 'Fix login timeout'
 
 # With inline description
 todo add 'Fix login timeout' 'Users experience timeouts after 30s'
+
+# With description flag
+todo add 'Fix login timeout' -d 'Users experience timeouts after 30s'
 
 # With rich description via stdin
 todo add 'Fix login timeout' <<'EOF'
@@ -40,7 +43,33 @@ The `handleLogin` function in `auth.go` needs a longer timeout:
 ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 ```
 EOF
+
+# With metadata flags
+todo add 'Fix login timeout' -t bug -p 3 -a 'Alice' --tags 'auth,urgent'
+
+# With parent ticket and external reference
+todo add 'Subtask of login fix' --parent aBc --external-ref JIRA-456
+
+# With design and acceptance criteria
+todo add 'Refactor auth' --design 'Extract token validation' --acceptance 'All tests pass'
+
+# Default title ("Untitled") when no args
+todo add -t epic -p 1
 ````
+
+**Flags:**
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--description` | `-d` | | Ticket description (overrides positional arg and stdin) |
+| `--type` | `-t` | `task` | Type: `bug`, `feature`, `task`, `epic`, `chore` |
+| `--priority` | `-p` | `2` | Priority: `0`–`4` |
+| `--assignee` | `-a` | `git user.name` | Assignee |
+| `--external-ref` | | | External reference (e.g. JIRA-123) |
+| `--parent` | | | Parent ticket ID (must exist) |
+| `--design` | | | Design notes |
+| `--acceptance` | | | Acceptance criteria |
+| `--tags` | | | Comma-separated tags |
 
 ### List tickets
 
@@ -115,13 +144,16 @@ Each file contains YAML frontmatter followed by the title and optional descripti
 ```markdown
 ---
 id: aBc
+type: task
+priority: 2
+assignee: Alice
 ---
 # Fix login timeout
 Description goes here.
 Multiple lines are supported.
 ```
 
-The YAML frontmatter block (`---` delimited) contains the ticket metadata. The `id` field is always present; additional fields like `status`, `type`, `priority`, `assignee`, `tags`, etc. are included only when set. The `# Title` heading follows the frontmatter. Everything after the title line is the description.
+The YAML frontmatter block (`---` delimited) contains the ticket metadata. The `id` field is always present. Other fields (`status`, `type`, `priority`, `assignee`, `external_ref`, `parent`, `design`, `acceptance`, `tags`, `deps`, `links`, `created`) are included only when set (empty values are omitted). The `# Title` heading follows the frontmatter. Everything after the title line is the description.
 
 ## License
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/juanibiapina/todo/internal/tickets"
@@ -11,13 +12,16 @@ import (
 )
 
 var addCmd = &cobra.Command{
-	Use:   "add <title> [description]",
+	Use:   "add [title] [description]",
 	Short: "Add a new ticket",
 	Long: `Add a new ticket with the given title.
 
+Title defaults to "Untitled" if not provided.
+
 Description can be provided as:
-  1. A positional argument (for simple text)
-  2. Via stdin (for multi-line content with special characters)
+  1. The -d/--description flag
+  2. A positional argument (for simple text)
+  3. Via stdin (for multi-line content with special characters)
 
 When stdin is not a terminal, the description is read from stdin.
 This allows heredocs and pipes for rich content:
@@ -33,12 +37,21 @@ This allows heredocs and pipes for rich content:
   EOF
 
   echo "Simple description" | todo add 'Fix bug'`,
-	Args: cobra.RangeArgs(1, 2),
+	Args: cobra.RangeArgs(0, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		title := args[0]
+		// Title: first arg or "Untitled"
+		title := "Untitled"
+		if len(args) > 0 {
+			title = args[0]
+		}
+
+		// Description priority: -d flag > 2nd positional arg > stdin
+		descFlag, _ := cmd.Flags().GetString("description")
 		var description string
 
-		if len(args) > 1 {
+		if descFlag != "" {
+			description = descFlag
+		} else if len(args) > 1 {
 			description = args[1]
 		} else {
 			// Check if stdin has data (not a terminal)
@@ -52,12 +65,67 @@ This allows heredocs and pipes for rich content:
 			}
 		}
 
+		// Get flag values
+		ticketType, _ := cmd.Flags().GetString("type")
+		priority, _ := cmd.Flags().GetInt("priority")
+		assignee, _ := cmd.Flags().GetString("assignee")
+		externalRef, _ := cmd.Flags().GetString("external-ref")
+		parent, _ := cmd.Flags().GetString("parent")
+		design, _ := cmd.Flags().GetString("design")
+		acceptance, _ := cmd.Flags().GetString("acceptance")
+		tagsStr, _ := cmd.Flags().GetString("tags")
+
+		// Validate type
+		validTypes := map[string]bool{
+			"bug": true, "feature": true, "task": true, "epic": true, "chore": true,
+		}
+		if !validTypes[ticketType] {
+			return fmt.Errorf("invalid type %q: must be one of bug, feature, task, epic, chore", ticketType)
+		}
+
+		// Validate priority
+		if priority < 0 || priority > 4 {
+			return fmt.Errorf("invalid priority %d: must be between 0 and 4", priority)
+		}
+
+		// Default assignee to git user.name if not set
+		if !cmd.Flags().Changed("assignee") {
+			gitName, err := exec.Command("git", "config", "user.name").Output()
+			if err == nil {
+				assignee = strings.TrimSpace(string(gitName))
+			}
+		}
+
+		// Parse tags
+		var tags []string
+		if tagsStr != "" {
+			for _, tag := range strings.Split(tagsStr, ",") {
+				tag = strings.TrimSpace(tag)
+				if tag != "" {
+					tags = append(tags, tag)
+				}
+			}
+		}
+
 		dir, err := os.Getwd()
 		if err != nil {
 			return err
 		}
 
-		ticket, err := tickets.Add(dir, title, description)
+		t := &tickets.Ticket{
+			Title:       title,
+			Description: description,
+			Type:        ticketType,
+			Priority:    priority,
+			Assignee:    assignee,
+			ExternalRef: externalRef,
+			Parent:      parent,
+			Design:      design,
+			Acceptance:  acceptance,
+			Tags:        tags,
+		}
+
+		ticket, err := tickets.Add(dir, t)
 		if err != nil {
 			return err
 		}
@@ -70,4 +138,14 @@ This allows heredocs and pipes for rich content:
 
 func init() {
 	rootCmd.AddCommand(addCmd)
+
+	addCmd.Flags().StringP("description", "d", "", "Ticket description")
+	addCmd.Flags().StringP("type", "t", "task", "Ticket type (bug/feature/task/epic/chore)")
+	addCmd.Flags().IntP("priority", "p", 2, "Priority (0-4)")
+	addCmd.Flags().StringP("assignee", "a", "", "Assignee (defaults to git user.name)")
+	addCmd.Flags().String("external-ref", "", "External reference (e.g. JIRA-123)")
+	addCmd.Flags().String("parent", "", "Parent ticket ID (must exist)")
+	addCmd.Flags().String("design", "", "Design notes")
+	addCmd.Flags().String("acceptance", "", "Acceptance criteria")
+	addCmd.Flags().String("tags", "", "Comma-separated tags")
 }

--- a/cmd/quick_add.go
+++ b/cmd/quick_add.go
@@ -37,7 +37,7 @@ adds the ticket, and exits immediately.`,
 			return err
 		}
 
-		ticket, err := tickets.Add(dir, title, "")
+		ticket, err := tickets.Add(dir, &tickets.Ticket{Title: title})
 		if err != nil {
 			return err
 		}

--- a/internal/tickets/ticket.go
+++ b/internal/tickets/ticket.go
@@ -19,6 +19,8 @@ type Ticket struct {
 	Created     string
 	Parent      string
 	ExternalRef string
+	Design      string
+	Acceptance  string
 	Deps        []string
 	Links       []string
 	Tags        []string
@@ -35,6 +37,8 @@ type frontmatter struct {
 	Created     string   `yaml:"created,omitempty"`
 	Parent      string   `yaml:"parent,omitempty"`
 	ExternalRef string   `yaml:"external_ref,omitempty"`
+	Design      string   `yaml:"design,omitempty"`
+	Acceptance  string   `yaml:"acceptance,omitempty"`
 	Deps        []string `yaml:"deps,omitempty"`
 	Links       []string `yaml:"links,omitempty"`
 	Tags        []string `yaml:"tags,omitempty"`
@@ -57,6 +61,8 @@ func (t *Ticket) FullString() string {
 		Created:     t.Created,
 		Parent:      t.Parent,
 		ExternalRef: t.ExternalRef,
+		Design:      t.Design,
+		Acceptance:  t.Acceptance,
 		Deps:        t.Deps,
 		Links:       t.Links,
 		Tags:        t.Tags,

--- a/internal/tickets/ticket_test.go
+++ b/internal/tickets/ticket_test.go
@@ -46,6 +46,8 @@ func TestFullStringWithAllFields(t *testing.T) {
 		Created:     "2026-01-15",
 		Parent:      "prt",
 		ExternalRef: "JIRA-123",
+		Design:      "Use microservices",
+		Acceptance:  "All tests pass",
 		Deps:        []string{"dep1", "dep2"},
 		Links:       []string{"lnk1"},
 		Tags:        []string{"backend", "urgent"},
@@ -68,6 +70,8 @@ func TestFullStringWithAllFields(t *testing.T) {
 		"created: \"2026-01-15\"",
 		"parent: prt",
 		"external_ref: JIRA-123",
+		"design: Use microservices",
+		"acceptance: All tests pass",
 		"deps:",
 		"- dep1",
 		"- dep2",
@@ -193,7 +197,7 @@ func TestFullStringOmitsEmptyStrings(t *testing.T) {
 
 	got := ticket.FullString()
 
-	omitted := []string{"status:", "type:", "assignee:", "created:", "parent:", "external_ref:"}
+	omitted := []string{"status:", "type:", "assignee:", "created:", "parent:", "external_ref:", "design:", "acceptance:"}
 	for _, field := range omitted {
 		if strings.Contains(got, field) {
 			t.Errorf("empty field %q should be omitted, got:\n%s", field, got)

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -339,7 +339,7 @@ func (m Model) updateDetailPanel(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m Model) addTicket(title string) tea.Cmd {
 	return func() tea.Msg {
-		t, err := tickets.Add(m.dir, title, "")
+		t, err := tickets.Add(m.dir, &tickets.Ticket{Title: title})
 		if err != nil {
 			return actionDoneMsg{message: fmt.Sprintf("Error: %v", err), isError: true}
 		}

--- a/test/add.bats
+++ b/test/add.bats
@@ -16,7 +16,7 @@ load test_helper
   assert_output --partial "Fix the bug"
 }
 
-@test "add: with description" {
+@test "add: with description as positional arg" {
   run todo add "Fix auth" "The auth handler needs work"
   assert_success
   assert_output --partial "Added"
@@ -76,4 +76,251 @@ load test_helper
   local count
   count="$(echo "${ids}" | wc -l | tr -d ' ')"
   [[ "${count}" -eq 3 ]]
+}
+
+# --- Default title ---
+
+@test "add: defaults to Untitled when no args" {
+  run todo add
+  assert_success
+  assert_output --partial "Added"
+  assert_output --partial "Untitled"
+}
+
+# --- Description flag ---
+
+@test "add: -d flag sets description" {
+  run todo add "Flag desc ticket" -d "Description via flag"
+  assert_success
+
+  local id
+  id="$(extract_id_from_add "${output}")"
+  run todo show "${id}"
+  assert_output --partial "Description via flag"
+}
+
+@test "add: -d flag takes priority over positional description" {
+  run todo add "Priority test" "positional desc" -d "flag desc"
+  assert_success
+
+  local id
+  id="$(extract_id_from_add "${output}")"
+  run todo show "${id}"
+  assert_output --partial "flag desc"
+  refute_output --partial "positional desc"
+}
+
+# --- Type flag ---
+
+@test "add: default type is task" {
+  run todo add "Default type ticket"
+  assert_success
+
+  local id
+  id="$(extract_id_from_add "${output}")"
+  run todo show "${id}"
+  assert_output --partial "type: task"
+}
+
+@test "add: -t flag sets type" {
+  run todo add "Bug ticket" -t bug
+  assert_success
+
+  local id
+  id="$(extract_id_from_add "${output}")"
+  run todo show "${id}"
+  assert_output --partial "type: bug"
+}
+
+@test "add: all valid types accepted" {
+  for type in bug feature task epic chore; do
+    run todo add "Type ${type}" -t "${type}"
+    assert_success
+  done
+}
+
+@test "add: invalid type returns error" {
+  run todo add "Bad type" -t invalid
+  assert_failure
+  assert_output --partial "invalid type"
+}
+
+# --- Priority flag ---
+
+@test "add: default priority is 2" {
+  run todo add "Default priority ticket"
+  assert_success
+
+  local id
+  id="$(extract_id_from_add "${output}")"
+  run todo show "${id}"
+  assert_output --partial "priority: 2"
+}
+
+@test "add: -p flag sets priority" {
+  run todo add "High priority" -p 4
+  assert_success
+
+  local id
+  id="$(extract_id_from_add "${output}")"
+  run todo show "${id}"
+  assert_output --partial "priority: 4"
+}
+
+@test "add: priority 0 is valid" {
+  run todo add "Zero priority" -p 0
+  assert_success
+}
+
+@test "add: priority out of range returns error" {
+  run todo add "Bad priority" -p 5
+  assert_failure
+  assert_output --partial "invalid priority"
+
+  run todo add "Bad priority" -p -1
+  assert_failure
+  assert_output --partial "invalid priority"
+}
+
+# --- Assignee flag ---
+
+@test "add: default assignee is git user.name" {
+  local git_name
+  git_name="$(git config user.name)"
+
+  run todo add "Assigned ticket"
+  assert_success
+
+  local id
+  id="$(extract_id_from_add "${output}")"
+  run todo show "${id}"
+  assert_output --partial "assignee: ${git_name}"
+}
+
+@test "add: -a flag overrides default assignee" {
+  run todo add "Custom assignee" -a "bob"
+  assert_success
+
+  local id
+  id="$(extract_id_from_add "${output}")"
+  run todo show "${id}"
+  assert_output --partial "assignee: bob"
+}
+
+# --- External ref flag ---
+
+@test "add: --external-ref sets external reference" {
+  run todo add "With ref" --external-ref "JIRA-456"
+  assert_success
+
+  local id
+  id="$(extract_id_from_add "${output}")"
+  run todo show "${id}"
+  assert_output --partial "external_ref: JIRA-456"
+}
+
+# --- Parent flag ---
+
+@test "add: --parent sets parent ticket" {
+  todo add "Parent ticket"
+  local parent_id
+  parent_id="$(todo list | awk '{print $1}')"
+
+  run todo add "Child ticket" --parent "${parent_id}"
+  assert_success
+
+  local id
+  id="$(extract_id_from_add "${output}")"
+  run todo show "${id}"
+  assert_output --partial "parent: ${parent_id}"
+}
+
+@test "add: --parent with non-existent ID returns error" {
+  run todo add "Bad parent" --parent "zzz"
+  assert_failure
+  assert_output --partial "parent ticket not found"
+}
+
+# --- Design flag ---
+
+@test "add: --design sets design notes" {
+  run todo add "With design" --design "Use microservices architecture"
+  assert_success
+
+  local id
+  id="$(extract_id_from_add "${output}")"
+  run todo show "${id}"
+  assert_output --partial "design: Use microservices architecture"
+}
+
+# --- Acceptance flag ---
+
+@test "add: --acceptance sets acceptance criteria" {
+  run todo add "With acceptance" --acceptance "All tests pass"
+  assert_success
+
+  local id
+  id="$(extract_id_from_add "${output}")"
+  run todo show "${id}"
+  assert_output --partial "acceptance: All tests pass"
+}
+
+# --- Tags flag ---
+
+@test "add: --tags sets comma-separated tags" {
+  run todo add "Tagged ticket" --tags "backend,urgent,v2"
+  assert_success
+
+  local id
+  id="$(extract_id_from_add "${output}")"
+  run todo show "${id}"
+  assert_output --partial "backend"
+  assert_output --partial "urgent"
+  assert_output --partial "v2"
+}
+
+@test "add: --tags handles spaces around commas" {
+  run todo add "Spaced tags" --tags "tag1 , tag2 , tag3"
+  assert_success
+
+  local id
+  id="$(extract_id_from_add "${output}")"
+  run todo show "${id}"
+  assert_output --partial "tag1"
+  assert_output --partial "tag2"
+  assert_output --partial "tag3"
+}
+
+# --- Combined flags ---
+
+@test "add: multiple flags together" {
+  todo add "Parent for combo"
+  local parent_id
+  parent_id="$(todo list | awk '{print $1}')"
+
+  run todo add "Full ticket" \
+    -d "Full description" \
+    -t feature \
+    -p 3 \
+    -a alice \
+    --external-ref "JIRA-789" \
+    --parent "${parent_id}" \
+    --design "REST API" \
+    --acceptance "200 OK responses" \
+    --tags "api,backend"
+  assert_success
+
+  local id
+  id="$(extract_id_from_add "${output}")"
+  run todo show "${id}"
+  assert_output --partial "type: feature"
+  assert_output --partial "priority: 3"
+  assert_output --partial "assignee: alice"
+  assert_output --partial "external_ref: JIRA-789"
+  assert_output --partial "parent: ${parent_id}"
+  assert_output --partial "design: REST API"
+  assert_output --partial "acceptance: 200 OK responses"
+  assert_output --partial "Full description"
+  assert_output --partial "api"
+  assert_output --partial "backend"
 }


### PR DESCRIPTION
Adds 9 creation flags to the `add` command with defaults, validation, and comprehensive integration tests. Refactors `Add()` to accept a `*Ticket` struct instead of individual parameters.

- Refactor `Add(dir, title, description string)` → `Add(dir string, t *Ticket)` for cleaner API with many fields
- Add `Design` and `Acceptance` fields to `Ticket` and `frontmatter` structs with `omitempty` YAML tags
- Add 9 cobra flags to `cmd/add.go`: `-d/--description`, `-t/--type` (default "task"), `-p/--priority` (default 2), `-a/--assignee` (default `git config user.name`), `--external-ref`, `--parent`, `--design`, `--acceptance`, `--tags` (comma-separated)
- Support default "Untitled" title when no args provided (`RangeArgs(0,2)`)
- Description priority: `-d` flag > 2nd positional arg > stdin
- Add parent ticket validation in `Add()` via `findTicketFile()` — returns error if parent doesn't exist
- Update callers: `cmd/quick_add.go` and `internal/tui/tui.go` to use new `Add(dir, &Ticket{})` signature
- Add `TestAddWithParentValidation` unit test and update existing tests for new `Add()` signature
- Add 21 new bats integration tests covering each flag, defaults, and validation (51 total bats tests)
- Update README with flags reference table and expanded examples
- Update CHANGELOG with new feature entries
