### PR TITLE
Add status management commands (status, start, close, reopen)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `todo add` flags: `-d/--description`, `-t/--type` (default `task`), `-p/--priority` (default `2`), `-a/--assignee` (default `git user.name`), `--external-ref`, `--parent` (validates existence), `--design`, `--acceptance`, `--tags` (comma-separated)
 - Default title "Untitled" when `todo add` is called with no arguments
 - Parent ticket validation: `--parent` must reference an existing ticket ID
+- `todo status <id> <status>` — set ticket status directly (valid: `open`, `in_progress`, `closed`)
+- `todo start <id>` — shortcut to set status to `in_progress`
+- `todo close <id>` — shortcut to set status to `closed`
+- `todo reopen <id>` — shortcut to set status to `open`
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,22 @@ todo done aBc
 
 This sets the ticket's status to `closed`. The ticket file is preserved on disk but hidden from `list` and the TUI. Use `show` to view closed tickets.
 
+### Manage ticket status
+
+Valid statuses: `open`, `in_progress`, `closed`.
+
+```bash
+# Set status directly
+todo status aBc in_progress
+
+# Shortcut commands
+todo start aBc      # set status to in_progress
+todo close aBc      # set status to closed
+todo reopen aBc     # set status to open
+```
+
+Closed tickets are hidden from `list` and the TUI. Use `reopen` to make them visible again.
+
 ### Interactive TUI
 
 ```bash

--- a/cmd/close.go
+++ b/cmd/close.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/juanibiapina/todo/internal/tickets"
+	"github.com/spf13/cobra"
+)
+
+var closeCmd = &cobra.Command{
+	Use:   "close <id>",
+	Short: "Close a ticket (set status to closed)",
+	Long:  `Set a ticket's status to closed.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id := args[0]
+
+		dir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		title, err := tickets.SetStatus(dir, id, "closed")
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Closed ticket: %s\n", title)
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(closeCmd)
+}

--- a/cmd/reopen.go
+++ b/cmd/reopen.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/juanibiapina/todo/internal/tickets"
+	"github.com/spf13/cobra"
+)
+
+var reopenCmd = &cobra.Command{
+	Use:   "reopen <id>",
+	Short: "Reopen a ticket (set status to open)",
+	Long:  `Set a ticket's status back to open.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id := args[0]
+
+		dir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		title, err := tickets.SetStatus(dir, id, "open")
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Reopened ticket: %s\n", title)
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(reopenCmd)
+}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/juanibiapina/todo/internal/tickets"
+	"github.com/spf13/cobra"
+)
+
+var startCmd = &cobra.Command{
+	Use:   "start <id>",
+	Short: "Start working on a ticket (set status to in_progress)",
+	Long:  `Set a ticket's status to in_progress.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id := args[0]
+
+		dir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		title, err := tickets.SetStatus(dir, id, "in_progress")
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Started ticket: %s\n", title)
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(startCmd)
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/juanibiapina/todo/internal/tickets"
+	"github.com/spf13/cobra"
+)
+
+var statusCmd = &cobra.Command{
+	Use:   "status <id> <status>",
+	Short: "Set the status of a ticket",
+	Long:  `Set the status of a ticket. Valid statuses: open, in_progress, closed.`,
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id := args[0]
+		status := args[1]
+
+		dir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		title, err := tickets.SetStatus(dir, id, status)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Status of %s set to %s\n", title, status)
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(statusCmd)
+}

--- a/internal/tickets/file.go
+++ b/internal/tickets/file.go
@@ -232,6 +232,38 @@ func Done(dir string, id string) (string, error) {
 	return t.Title, nil
 }
 
+// validStatuses lists the allowed ticket statuses.
+var validStatuses = map[string]bool{
+	"open":        true,
+	"in_progress": true,
+	"closed":      true,
+}
+
+// SetStatus changes a ticket's status after validation.
+func SetStatus(dir string, id string, status string) (string, error) {
+	if !validStatuses[status] {
+		return "", fmt.Errorf("invalid status: %q (valid: open, in_progress, closed)", status)
+	}
+
+	path, err := findTicketFile(dir, id)
+	if err != nil {
+		return "", err
+	}
+
+	t, err := parseFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	t.Status = status
+
+	if err := writeFile(dir, t); err != nil {
+		return "", err
+	}
+
+	return t.Title, nil
+}
+
 // SetDescription sets or replaces a ticket's description.
 func SetDescription(dir string, id string, description string) (string, error) {
 	path, err := findTicketFile(dir, id)

--- a/internal/tickets/file_test.go
+++ b/internal/tickets/file_test.go
@@ -464,6 +464,88 @@ func TestAddWithParentValidation(t *testing.T) {
 	}
 }
 
+func TestSetStatus(t *testing.T) {
+	dir := tempDir(t)
+
+	ticket, err := Add(dir, &Ticket{Title: "Status test"})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	// Set to in_progress
+	title, err := SetStatus(dir, ticket.ID, "in_progress")
+	if err != nil {
+		t.Fatalf("SetStatus: %v", err)
+	}
+	if title != "Status test" {
+		t.Errorf("title = %q, want %q", title, "Status test")
+	}
+
+	loaded, err := Show(dir, ticket.ID)
+	if err != nil {
+		t.Fatalf("Show: %v", err)
+	}
+	if loaded.Status != "in_progress" {
+		t.Errorf("status = %q, want %q", loaded.Status, "in_progress")
+	}
+
+	// Set to closed
+	_, err = SetStatus(dir, ticket.ID, "closed")
+	if err != nil {
+		t.Fatalf("SetStatus closed: %v", err)
+	}
+	loaded, err = Show(dir, ticket.ID)
+	if err != nil {
+		t.Fatalf("Show: %v", err)
+	}
+	if loaded.Status != "closed" {
+		t.Errorf("status = %q, want %q", loaded.Status, "closed")
+	}
+
+	// Set to open
+	_, err = SetStatus(dir, ticket.ID, "open")
+	if err != nil {
+		t.Fatalf("SetStatus open: %v", err)
+	}
+	loaded, err = Show(dir, ticket.ID)
+	if err != nil {
+		t.Fatalf("Show: %v", err)
+	}
+	if loaded.Status != "open" {
+		t.Errorf("status = %q, want %q", loaded.Status, "open")
+	}
+}
+
+func TestSetStatusInvalid(t *testing.T) {
+	dir := tempDir(t)
+
+	ticket, err := Add(dir, &Ticket{Title: "Invalid status test"})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	_, err = SetStatus(dir, ticket.ID, "invalid")
+	if err == nil {
+		t.Error("SetStatus with invalid status should fail")
+	}
+	if err != nil && !strings.Contains(err.Error(), "invalid status") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSetStatusNotFound(t *testing.T) {
+	dir := tempDir(t)
+	EnsureDir(dir)
+
+	_, err := SetStatus(dir, "zzz", "open")
+	if err == nil {
+		t.Error("SetStatus with non-existent ID should fail")
+	}
+	if err != nil && !strings.Contains(err.Error(), "ticket not found") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 func TestParseFileDescriptionWithDashes(t *testing.T) {
 	dir := tempDir(t)
 	EnsureDir(dir)

--- a/test/close.bats
+++ b/test/close.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "close: sets status to closed" {
+  local out
+  out="$(todo add "Close me")"
+  local id
+  id="$(echo "${out}" | awk '{print $2}')"
+
+  run todo close "${id}"
+  assert_success
+  assert_output --partial "Closed ticket"
+  assert_output --partial "Close me"
+
+  run todo show "${id}"
+  assert_success
+  assert_output --partial "status: closed"
+}
+
+@test "close: hides ticket from list" {
+  local out
+  out="$(todo add "Will be closed")"
+  local id
+  id="$(echo "${out}" | awk '{print $2}')"
+
+  todo close "${id}"
+
+  run todo list
+  refute_output --partial "Will be closed"
+}
+
+@test "close: fails for nonexistent ticket" {
+  run todo close "ZZZ"
+  assert_failure
+  assert_output --partial "ticket not found"
+}
+
+@test "close: file still exists on disk" {
+  local out
+  out="$(todo add "Persisted close")"
+  local id
+  id="$(echo "${out}" | awk '{print $2}')"
+
+  todo close "${id}"
+
+  [[ -f "docs/tickets/${id}.md" ]]
+}

--- a/test/reopen.bats
+++ b/test/reopen.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "reopen: sets status to open" {
+  local out
+  out="$(todo add "Reopen me")"
+  local id
+  id="$(echo "${out}" | awk '{print $2}')"
+
+  todo close "${id}"
+  run todo show "${id}"
+  assert_output --partial "status: closed"
+
+  run todo reopen "${id}"
+  assert_success
+  assert_output --partial "Reopened ticket"
+  assert_output --partial "Reopen me"
+
+  run todo show "${id}"
+  assert_success
+  assert_output --partial "status: open"
+}
+
+@test "reopen: ticket reappears in list" {
+  local out
+  out="$(todo add "Come back")"
+  local id
+  id="$(echo "${out}" | awk '{print $2}')"
+
+  todo close "${id}"
+  run todo list
+  refute_output --partial "Come back"
+
+  todo reopen "${id}"
+  run todo list
+  assert_output --partial "Come back"
+}
+
+@test "reopen: fails for nonexistent ticket" {
+  run todo reopen "ZZZ"
+  assert_failure
+  assert_output --partial "ticket not found"
+}
+
+@test "reopen: works after done command" {
+  local out
+  out="$(todo add "Done then reopen")"
+  local id
+  id="$(echo "${out}" | awk '{print $2}')"
+
+  todo done "${id}"
+  run todo show "${id}"
+  assert_output --partial "status: closed"
+
+  run todo reopen "${id}"
+  assert_success
+
+  run todo show "${id}"
+  assert_output --partial "status: open"
+
+  run todo list
+  assert_output --partial "Done then reopen"
+}

--- a/test/start.bats
+++ b/test/start.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "start: sets status to in_progress" {
+  local out
+  out="$(todo add "Start test")"
+  local id
+  id="$(echo "${out}" | awk '{print $2}')"
+
+  run todo start "${id}"
+  assert_success
+  assert_output --partial "Started ticket"
+  assert_output --partial "Start test"
+
+  run todo show "${id}"
+  assert_success
+  assert_output --partial "status: in_progress"
+}
+
+@test "start: fails for nonexistent ticket" {
+  run todo start "ZZZ"
+  assert_failure
+  assert_output --partial "ticket not found"
+}
+
+@test "start: ticket remains visible in list" {
+  local out
+  out="$(todo add "Keep visible")"
+  local id
+  id="$(echo "${out}" | awk '{print $2}')"
+
+  todo start "${id}"
+
+  run todo list
+  assert_output --partial "Keep visible"
+}

--- a/test/status.bats
+++ b/test/status.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "status: sets status to open" {
+  local out
+  out="$(todo add "Status test")"
+  local id
+  id="$(echo "${out}" | awk '{print $2}')"
+
+  run todo status "${id}" open
+  assert_success
+  assert_output --partial "Status of"
+  assert_output --partial "set to open"
+
+  run todo show "${id}"
+  assert_success
+  assert_output --partial "status: open"
+}
+
+@test "status: sets status to in_progress" {
+  local out
+  out="$(todo add "Progress test")"
+  local id
+  id="$(echo "${out}" | awk '{print $2}')"
+
+  run todo status "${id}" in_progress
+  assert_success
+  assert_output --partial "set to in_progress"
+
+  run todo show "${id}"
+  assert_success
+  assert_output --partial "status: in_progress"
+}
+
+@test "status: sets status to closed" {
+  local out
+  out="$(todo add "Close test")"
+  local id
+  id="$(echo "${out}" | awk '{print $2}')"
+
+  run todo status "${id}" closed
+  assert_success
+  assert_output --partial "set to closed"
+
+  run todo show "${id}"
+  assert_success
+  assert_output --partial "status: closed"
+}
+
+@test "status: rejects invalid status" {
+  local out
+  out="$(todo add "Invalid test")"
+  local id
+  id="$(echo "${out}" | awk '{print $2}')"
+
+  run todo status "${id}" invalid
+  assert_failure
+  assert_output --partial "invalid status"
+}
+
+@test "status: fails for nonexistent ticket" {
+  run todo status "ZZZ" open
+  assert_failure
+  assert_output --partial "ticket not found"
+}
+
+@test "status: closed ticket hidden from list" {
+  local out
+  out="$(todo add "Will close")"
+  local id
+  id="$(echo "${out}" | awk '{print $2}')"
+
+  todo status "${id}" closed
+
+  run todo list
+  refute_output --partial "Will close"
+}
+
+@test "status: reopened ticket visible in list" {
+  local out
+  out="$(todo add "Will reopen")"
+  local id
+  id="$(echo "${out}" | awk '{print $2}')"
+
+  todo status "${id}" closed
+
+  run todo list
+  refute_output --partial "Will reopen"
+
+  todo status "${id}" open
+
+  run todo list
+  assert_output --partial "Will reopen"
+}


### PR DESCRIPTION
Adds status management commands for ticket lifecycle control. Tickets can now transition between `open`, `in_progress`, and `closed` statuses with validation.

- Add `SetStatus(dir, id, status string)` to `internal/tickets/file.go` with validation against allowed statuses (`open`, `in_progress`, `closed`)
- Add `todo status <id> <status>` command for setting arbitrary valid status
- Add `todo start <id>` shortcut command (sets `in_progress`)
- Add `todo close <id>` shortcut command (sets `closed`)
- Add `todo reopen <id>` shortcut command (sets `open`)
- Add 3 unit tests: `TestSetStatus`, `TestSetStatusInvalid`, `TestSetStatusNotFound`
- Add 18 bats integration tests across 4 new test files (`test/status.bats`, `test/start.bats`, `test/close.bats`, `test/reopen.bats`)
- Update README.md with "Manage ticket status" section and usage examples
- Update CHANGELOG.md with new command entries

All 37 unit tests and 69 bats integration tests pass.