### PR TITLE
Add partial ID matching to all ticket commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `todo start <id>` — shortcut to set status to `in_progress`
 - `todo close <id>` — shortcut to set status to `closed`
 - `todo reopen <id>` — shortcut to set status to `open`
+- Partial ID matching: all commands accepting a ticket ID now support substring matching (exact match takes precedence; ambiguous matches produce an error)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,21 @@ IDs are color-coded (magenta) when output is a terminal.
 todo show aBc
 ```
 
+### Partial ID matching
+
+All commands that accept a ticket ID support partial matching. You can use any unique substring of the ID:
+
+```bash
+# These all work if "aBc" is the only ticket containing "aB"
+todo show aB
+todo done aB
+todo start aB
+todo status aB in_progress
+todo set-description aB 'Updated description'
+```
+
+Exact matches always take precedence. If a partial ID matches multiple tickets, an error lists the ambiguous IDs.
+
 ### Set description
 
 ```bash

--- a/test/partial_id.bats
+++ b/test/partial_id.bats
@@ -1,0 +1,171 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "partial id: show with exact match" {
+  local out
+  out="$(todo add "Exact match")"
+  local id
+  id="$(extract_id_from_add "${out}")"
+
+  run todo show "${id}"
+  assert_success
+  assert_output --partial "Exact match"
+}
+
+@test "partial id: show with prefix" {
+  local out
+  out="$(todo add "Prefix test")"
+  local id
+  id="$(extract_id_from_add "${out}")"
+
+  # Use first 2 chars as prefix
+  local prefix="${id:0:2}"
+
+  run todo show "${prefix}"
+  assert_success
+  assert_output --partial "Prefix test"
+}
+
+@test "partial id: show with suffix" {
+  local out
+  out="$(todo add "Suffix test")"
+  local id
+  id="$(extract_id_from_add "${out}")"
+
+  # Use last 2 chars as suffix
+  local suffix="${id:1:2}"
+
+  run todo show "${suffix}"
+  assert_success
+  assert_output --partial "Suffix test"
+}
+
+@test "partial id: done with partial id" {
+  local out
+  out="$(todo add "Done partial")"
+  local id
+  id="$(extract_id_from_add "${out}")"
+
+  local prefix="${id:0:2}"
+
+  run todo done "${prefix}"
+  assert_success
+
+  # Verify it was closed
+  run todo show "${id}"
+  assert_success
+  assert_output --partial "status: closed"
+}
+
+@test "partial id: status with partial id" {
+  local out
+  out="$(todo add "Status partial")"
+  local id
+  id="$(extract_id_from_add "${out}")"
+
+  local prefix="${id:0:2}"
+
+  run todo status "${prefix}" in_progress
+  assert_success
+
+  run todo show "${id}"
+  assert_success
+  assert_output --partial "status: in_progress"
+}
+
+@test "partial id: start with partial id" {
+  local out
+  out="$(todo add "Start partial")"
+  local id
+  id="$(extract_id_from_add "${out}")"
+
+  local prefix="${id:0:2}"
+
+  run todo start "${prefix}"
+  assert_success
+
+  run todo show "${id}"
+  assert_success
+  assert_output --partial "status: in_progress"
+}
+
+@test "partial id: close with partial id" {
+  local out
+  out="$(todo add "Close partial")"
+  local id
+  id="$(extract_id_from_add "${out}")"
+
+  local prefix="${id:0:2}"
+
+  run todo close "${prefix}"
+  assert_success
+
+  run todo show "${id}"
+  assert_success
+  assert_output --partial "status: closed"
+}
+
+@test "partial id: reopen with partial id" {
+  local out
+  out="$(todo add "Reopen partial")"
+  local id
+  id="$(extract_id_from_add "${out}")"
+
+  todo done "${id}"
+
+  local prefix="${id:0:2}"
+
+  run todo reopen "${prefix}"
+  assert_success
+
+  run todo show "${id}"
+  assert_success
+  assert_output --partial "status: open"
+}
+
+@test "partial id: set-description with partial id" {
+  local out
+  out="$(todo add "Desc partial")"
+  local id
+  id="$(extract_id_from_add "${out}")"
+
+  local prefix="${id:0:2}"
+
+  run todo set-description "${prefix}" "New description"
+  assert_success
+
+  run todo show "${id}"
+  assert_success
+  assert_output --partial "New description"
+}
+
+@test "partial id: not found" {
+  run todo show "ZZZZZZ"
+  assert_failure
+  assert_output --partial "ticket not found"
+}
+
+@test "partial id: exact match takes precedence" {
+  # Create two tickets with controlled IDs by writing files directly
+  mkdir -p docs/tickets
+
+  cat > docs/tickets/ab.md << 'EOF'
+---
+id: ab
+---
+# Exact
+EOF
+
+  cat > docs/tickets/abc.md << 'EOF'
+---
+id: abc
+---
+# Longer
+EOF
+
+  # "ab" should exact-match "ab", not ambiguously match both
+  run todo show "ab"
+  assert_success
+  assert_output --partial "# Exact"
+}


### PR DESCRIPTION
Enhances `findTicketFile()` to support partial ID matching via substring search, so users don't need to type the full 3-character ticket ID.

- Rewrote `findTicketFile()` in `internal/tickets/file.go`: exact match via `os.Stat()` first, then scans `.md` files for substring matches using `strings.Contains()`
- 0 matches → `"ticket not found: %s"` error; 1 match → returns that path; 2+ matches → `"ambiguous ticket ID %q: matches %s"` error with sorted IDs
- All commands that take a ticket ID (show, done, close, start, reopen, status, set-description, parent validation) automatically gain partial matching — no caller changes needed
- Added 6 unit tests in `internal/tickets/file_test.go`: prefix, suffix, substring, ambiguous, exact precedence, not-found
- Created `test/partial_id.bats` with 11 integration tests covering partial IDs across all affected commands
- Updated README.md with "Partial ID matching" section and CHANGELOG.md with feature entry
- All 43 unit tests and 80 bats integration tests pass
