### PR TITLE
Add dep/undep commands for ticket dependency management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `todo close <id>` — shortcut to set status to `closed`
 - `todo reopen <id>` — shortcut to set status to `open`
 - Partial ID matching: all commands accepting a ticket ID now support substring matching (exact match takes precedence; ambiguous matches produce an error)
+- `todo dep <id> <dep-id>` — add a dependency between tickets (idempotent, validates both exist)
+- `todo undep <id> <dep-id>` — remove a dependency between tickets (idempotent, validates both exist)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,18 @@ todo reopen aBc     # set status to open
 
 Closed tickets are hidden from `list` and the TUI. Use `reopen` to make them visible again.
 
+### Manage dependencies
+
+```bash
+# Add a dependency (ticket aBc depends on xYz)
+todo dep aBc xYz
+
+# Remove a dependency
+todo undep aBc xYz
+```
+
+Both commands validate that the referenced tickets exist. Operations are idempotent — adding an existing dependency or removing a non-existent one succeeds silently. Partial ID matching is supported for both arguments.
+
 ### Interactive TUI
 
 ```bash

--- a/cmd/dep.go
+++ b/cmd/dep.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/juanibiapina/todo/internal/tickets"
+	"github.com/spf13/cobra"
+)
+
+var depCmd = &cobra.Command{
+	Use:   "dep <id> <dep-id>",
+	Short: "Add a dependency to a ticket",
+	Long:  `Add a dependency from one ticket to another. Both tickets must exist. The operation is idempotent.`,
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id := args[0]
+		depID := args[1]
+
+		dir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		err = tickets.AddDep(dir, id, depID)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Added dependency %s to %s\n", depID, id)
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(depCmd)
+}

--- a/cmd/undep.go
+++ b/cmd/undep.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/juanibiapina/todo/internal/tickets"
+	"github.com/spf13/cobra"
+)
+
+var undepCmd = &cobra.Command{
+	Use:   "undep <id> <dep-id>",
+	Short: "Remove a dependency from a ticket",
+	Long:  `Remove a dependency from a ticket. Both tickets must exist. The operation is idempotent.`,
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id := args[0]
+		depID := args[1]
+
+		dir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		err = tickets.RemoveDep(dir, id, depID)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Removed dependency %s from %s\n", depID, id)
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(undepCmd)
+}

--- a/test/dep.bats
+++ b/test/dep.bats
@@ -1,0 +1,143 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "dep adds a dependency" {
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "Ticket B"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  run todo dep "${id_a}" "${id_b}"
+  assert_success
+  assert_output "Added dependency ${id_b} to ${id_a}"
+
+  run todo show "${id_a}"
+  assert_success
+  assert_output --partial "deps:"
+  assert_output --partial "${id_b}"
+}
+
+@test "dep is idempotent" {
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "Ticket B"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  run todo dep "${id_a}" "${id_b}"
+  assert_success
+
+  run todo dep "${id_a}" "${id_b}"
+  assert_success
+
+  # Should only have one dep entry, not two
+  run todo show "${id_a}"
+  assert_success
+  # Count occurrences of the dep ID in deps section
+  local count
+  count=$(echo "$output" | grep -c "${id_b}" || true)
+  [ "$count" -eq 1 ]
+}
+
+@test "dep fails when ticket does not exist" {
+  run todo add "Ticket B"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  run todo dep "zzz" "${id_b}"
+  assert_failure
+  assert_output --partial "ticket not found"
+}
+
+@test "dep fails when dependency does not exist" {
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo dep "${id_a}" "zzz"
+  assert_failure
+  assert_output --partial "ticket not found"
+}
+
+@test "dep works with partial IDs" {
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "Ticket B"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  # Use first 2 chars as partial IDs
+  local partial_a="${id_a:0:2}"
+  local partial_b="${id_b:0:2}"
+
+  run todo dep "${partial_a}" "${partial_b}"
+  assert_success
+
+  # Verify the full resolved ID is stored
+  run todo show "${id_a}"
+  assert_success
+  assert_output --partial "${id_b}"
+}
+
+@test "dep supports multiple dependencies" {
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "Ticket B"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  run todo add "Ticket C"
+  local id_c
+  id_c="$(extract_id_from_add "$output")"
+
+  run todo dep "${id_a}" "${id_b}"
+  assert_success
+
+  run todo dep "${id_a}" "${id_c}"
+  assert_success
+
+  run todo show "${id_a}"
+  assert_success
+  assert_output --partial "${id_b}"
+  assert_output --partial "${id_c}"
+}
+
+@test "dep does not modify the dependency ticket" {
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "Ticket B"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  run todo dep "${id_a}" "${id_b}"
+  assert_success
+
+  # The dependency ticket should have no deps
+  run todo show "${id_b}"
+  assert_success
+  refute_output --partial "deps:"
+}
+
+@test "dep requires exactly 2 arguments" {
+  run todo dep
+  assert_failure
+
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo dep "${id_a}"
+  assert_failure
+}

--- a/test/undep.bats
+++ b/test/undep.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "undep removes a dependency" {
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "Ticket B"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  run todo dep "${id_a}" "${id_b}"
+  assert_success
+
+  run todo undep "${id_a}" "${id_b}"
+  assert_success
+  assert_output "Removed dependency ${id_b} from ${id_a}"
+
+  run todo show "${id_a}"
+  assert_success
+  refute_output --partial "deps:"
+}
+
+@test "undep is idempotent" {
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "Ticket B"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  run todo dep "${id_a}" "${id_b}"
+  assert_success
+
+  run todo undep "${id_a}" "${id_b}"
+  assert_success
+
+  # Removing again should still succeed
+  run todo undep "${id_a}" "${id_b}"
+  assert_success
+}
+
+@test "undep fails when ticket does not exist" {
+  run todo add "Ticket B"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  run todo undep "zzz" "${id_b}"
+  assert_failure
+  assert_output --partial "ticket not found"
+}
+
+@test "undep works with partial IDs" {
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "Ticket B"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  run todo dep "${id_a}" "${id_b}"
+  assert_success
+
+  # Use first 2 chars as partial IDs
+  local partial_a="${id_a:0:2}"
+  local partial_b="${id_b:0:2}"
+
+  run todo undep "${partial_a}" "${partial_b}"
+  assert_success
+
+  run todo show "${id_a}"
+  assert_success
+  refute_output --partial "deps:"
+}
+
+@test "undep requires exactly 2 arguments" {
+  run todo undep
+  assert_failure
+
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo undep "${id_a}"
+  assert_failure
+}


### PR DESCRIPTION
Adds `dep` and `undep` commands for managing ticket dependencies, stored as a YAML array in ticket frontmatter.

- Add `AddDep(dir, id, depID string) error` and `RemoveDep(dir, id, depID string) error` in `internal/tickets/file.go` — both validate that referenced tickets exist via `findTicketFile`, store resolved (full) IDs, and are idempotent
- Add `cmd/dep.go` — `todo dep <id> <dep-id>` adds a dependency, outputs `"Added dependency %s to %s"`
- Add `cmd/undep.go` — `todo undep <id> <dep-id>` removes a dependency, outputs `"Removed dependency %s from %s"`
- Add 7 unit tests in `internal/tickets/file_test.go`: AddDep, AddDepIdempotent, AddDepTicketNotFound, AddDepDepNotFound, RemoveDep, RemoveDepNotPresent, RemoveDepTicketNotFound
- Add `test/dep.bats` (8 integration tests) and `test/undep.bats` (5 integration tests) covering add/remove, idempotency, validation errors, partial ID support, multiple deps
- Update README.md with "Manage dependencies" section and CHANGELOG.md with new entries
- All 50 unit tests and 93 bats integration tests pass