### PR TITLE
Add dep tree command with box-drawing output and cycle detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Partial ID matching: all commands accepting a ticket ID now support substring matching (exact match takes precedence; ambiguous matches produce an error)
 - `todo dep <id> <dep-id>` — add a dependency between tickets (idempotent, validates both exist)
 - `todo undep <id> <dep-id>` — remove a dependency between tickets (idempotent, validates both exist)
+- `todo dep tree <id>` — display dependency tree with box-drawing characters, `[status]` labels, cycle/dedup markers, and `--full` flag to disable deduplication
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,22 @@ todo undep aBc xYz
 
 Both commands validate that the referenced tickets exist. Operations are idempotent — adding an existing dependency or removing a non-existent one succeeds silently. Partial ID matching is supported for both arguments.
 
+#### Dependency tree
+
+```bash
+# Show dependency tree
+todo dep tree aBc
+# aBc Fix login timeout
+# ├── xYz [in_progress] Refactor auth module
+# │   └── qRs Validate tokens
+# └── mNp Write tests
+
+# Show full tree (no deduplication)
+todo dep tree aBc --full
+```
+
+The tree uses box-drawing characters (`├── `, `└── `, `│   `) and shows `[status]` when set. Children are sorted by subtree depth (deepest first), then by ID. Cycles are marked with `(cycle)` and duplicate nodes with `(dup)`. Use `--full` to disable deduplication.
+
 ### Interactive TUI
 
 ```bash

--- a/cmd/dep_tree.go
+++ b/cmd/dep_tree.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/juanibiapina/todo/internal/tickets"
+	"github.com/spf13/cobra"
+)
+
+var depTreeCmd = &cobra.Command{
+	Use:   "tree <id>",
+	Short: "Show dependency tree for a ticket",
+	Long:  `Display a tree of dependencies for a ticket using box-drawing characters.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id := args[0]
+		full, _ := cmd.Flags().GetBool("full")
+
+		dir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		output, err := tickets.DepTree(dir, id, full)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(output)
+
+		return nil
+	},
+}
+
+func init() {
+	depTreeCmd.Flags().Bool("full", false, "Show full tree without deduplication")
+	depCmd.AddCommand(depTreeCmd)
+}

--- a/internal/tickets/tree.go
+++ b/internal/tickets/tree.go
@@ -1,0 +1,160 @@
+package tickets
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// treeNode represents a node in the dependency tree.
+type treeNode struct {
+	ticket   *Ticket
+	children []*treeNode
+	marker   string // "", "(cycle)", or "(dup)"
+}
+
+// DepTree generates a dependency tree string for the given ticket ID.
+// If full is true, deduplication is disabled (same ticket can appear multiple times).
+func DepTree(dir string, id string, full bool) (string, error) {
+	// Resolve the ticket ID (supports partial matching)
+	path, err := findTicketFile(dir, id)
+	if err != nil {
+		return "", err
+	}
+	resolvedID := strings.TrimSuffix(filepath.Base(path), ".md")
+
+	// Load all tickets and build a lookup map
+	allTickets, err := List(dir)
+	if err != nil {
+		return "", err
+	}
+	ticketMap := make(map[string]*Ticket)
+	for _, t := range allTickets {
+		ticketMap[t.ID] = t
+	}
+
+	root, ok := ticketMap[resolvedID]
+	if !ok {
+		return "", fmt.Errorf("ticket not found: %s", id)
+	}
+
+	// Build tree with cycle and dedup tracking
+	ancestors := make(map[string]bool)
+	visited := make(map[string]bool)
+	rootNode := buildTreeNode(root, ticketMap, ancestors, visited, full)
+
+	return formatTree(rootNode), nil
+}
+
+// buildTreeNode recursively builds a tree node from a ticket.
+// ancestors tracks the current path for cycle detection.
+// visited tracks all expanded nodes for dedup (when full is false).
+func buildTreeNode(t *Ticket, ticketMap map[string]*Ticket, ancestors, visited map[string]bool, full bool) *treeNode {
+	node := &treeNode{ticket: t}
+
+	// Cycle detection: this ticket is an ancestor in the current path
+	if ancestors[t.ID] {
+		node.marker = "(cycle)"
+		return node
+	}
+
+	// Dedup: this ticket was already expanded elsewhere (default mode only)
+	if !full && visited[t.ID] {
+		node.marker = "(dup)"
+		return node
+	}
+
+	// Mark as ancestor (for cycle detection) and visited (for dedup)
+	ancestors[t.ID] = true
+	visited[t.ID] = true
+	defer func() { delete(ancestors, t.ID) }()
+
+	// Build children from deps
+	var children []*treeNode
+	for _, depID := range t.Deps {
+		depTicket, ok := ticketMap[depID]
+		if !ok {
+			continue // skip missing deps
+		}
+		child := buildTreeNode(depTicket, ticketMap, ancestors, visited, full)
+		children = append(children, child)
+	}
+
+	// Sort children: subtree depth descending, then ID ascending
+	sort.Slice(children, func(i, j int) bool {
+		di := subtreeDepth(children[i])
+		dj := subtreeDepth(children[j])
+		if di != dj {
+			return di > dj
+		}
+		return children[i].ticket.ID < children[j].ticket.ID
+	})
+
+	node.children = children
+	return node
+}
+
+// subtreeDepth returns the maximum depth of a node's subtree.
+// Nodes with markers (cycle/dup) or no children have depth 0.
+func subtreeDepth(n *treeNode) int {
+	if n.marker != "" || len(n.children) == 0 {
+		return 0
+	}
+	maxDepth := 0
+	for _, child := range n.children {
+		d := subtreeDepth(child)
+		if d > maxDepth {
+			maxDepth = d
+		}
+	}
+	return maxDepth + 1
+}
+
+// formatTree renders a tree node and its children with box-drawing characters.
+// Returns the formatted string without a trailing newline.
+func formatTree(root *treeNode) string {
+	var b strings.Builder
+	b.WriteString(formatNodeLine(root))
+	formatChildren(&b, root.children, "")
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// formatChildren recursively renders child nodes with appropriate prefixes.
+func formatChildren(b *strings.Builder, children []*treeNode, prefix string) {
+	for i, child := range children {
+		isLast := i == len(children)-1
+
+		connector := "├── "
+		if isLast {
+			connector = "└── "
+		}
+
+		b.WriteString(prefix)
+		b.WriteString(connector)
+		b.WriteString(formatNodeLine(child))
+
+		// Only recurse into children if no marker (cycle/dup stops expansion)
+		if child.marker == "" {
+			childPrefix := prefix + "│   "
+			if isLast {
+				childPrefix = prefix + "    "
+			}
+			formatChildren(b, child.children, childPrefix)
+		}
+	}
+}
+
+// formatNodeLine renders a single node as "id [status] Title [marker]\n".
+func formatNodeLine(n *treeNode) string {
+	var parts []string
+	parts = append(parts, n.ticket.ID)
+	if n.ticket.Status != "" {
+		parts = append(parts, fmt.Sprintf("[%s]", n.ticket.Status))
+	}
+	parts = append(parts, n.ticket.Title)
+	if n.marker != "" {
+		parts = append(parts, n.marker)
+	}
+	return strings.Join(parts, " ") + "\n"
+}

--- a/internal/tickets/tree_test.go
+++ b/internal/tickets/tree_test.go
@@ -1,0 +1,161 @@
+package tickets
+
+import (
+	"testing"
+)
+
+func TestDepTreeNoDeps(t *testing.T) {
+	dir := tempDir(t)
+	EnsureDir(dir)
+
+	writeFile(dir, &Ticket{ID: "aaa", Title: "Root ticket", Status: "open"})
+
+	result, err := DepTree(dir, "aaa", false)
+	if err != nil {
+		t.Fatalf("DepTree: %v", err)
+	}
+
+	expected := "aaa [open] Root ticket"
+	if result != expected {
+		t.Errorf("got:\n%s\nwant:\n%s", result, expected)
+	}
+}
+
+func TestDepTreeSimple(t *testing.T) {
+	dir := tempDir(t)
+	EnsureDir(dir)
+
+	writeFile(dir, &Ticket{ID: "aaa", Title: "Root", Deps: []string{"bbb"}})
+	writeFile(dir, &Ticket{ID: "bbb", Title: "Child"})
+
+	result, err := DepTree(dir, "aaa", false)
+	if err != nil {
+		t.Fatalf("DepTree: %v", err)
+	}
+
+	expected := "aaa Root\n└── bbb Child"
+	if result != expected {
+		t.Errorf("got:\n%s\nwant:\n%s", result, expected)
+	}
+}
+
+func TestDepTreeNested(t *testing.T) {
+	dir := tempDir(t)
+	EnsureDir(dir)
+
+	writeFile(dir, &Ticket{ID: "aaa", Title: "Root", Deps: []string{"bbb"}})
+	writeFile(dir, &Ticket{ID: "bbb", Title: "Mid", Deps: []string{"ccc"}})
+	writeFile(dir, &Ticket{ID: "ccc", Title: "Leaf"})
+
+	result, err := DepTree(dir, "aaa", false)
+	if err != nil {
+		t.Fatalf("DepTree: %v", err)
+	}
+
+	expected := "aaa Root\n└── bbb Mid\n    └── ccc Leaf"
+	if result != expected {
+		t.Errorf("got:\n%s\nwant:\n%s", result, expected)
+	}
+}
+
+func TestDepTreeSorting(t *testing.T) {
+	dir := tempDir(t)
+	EnsureDir(dir)
+
+	// aaa depends on bbb (depth 0) and ccc (depth 1, since ccc → ddd)
+	writeFile(dir, &Ticket{ID: "aaa", Title: "Root", Deps: []string{"bbb", "ccc"}})
+	writeFile(dir, &Ticket{ID: "bbb", Title: "Shallow"})
+	writeFile(dir, &Ticket{ID: "ccc", Title: "Deep", Deps: []string{"ddd"}})
+	writeFile(dir, &Ticket{ID: "ddd", Title: "Leaf"})
+
+	result, err := DepTree(dir, "aaa", false)
+	if err != nil {
+		t.Fatalf("DepTree: %v", err)
+	}
+
+	// ccc (depth 1) should come before bbb (depth 0) because deeper first
+	expected := "aaa Root\n├── ccc Deep\n│   └── ddd Leaf\n└── bbb Shallow"
+	if result != expected {
+		t.Errorf("got:\n%s\nwant:\n%s", result, expected)
+	}
+}
+
+func TestDepTreeCycle(t *testing.T) {
+	dir := tempDir(t)
+	EnsureDir(dir)
+
+	writeFile(dir, &Ticket{ID: "aaa", Title: "Root", Deps: []string{"bbb"}})
+	writeFile(dir, &Ticket{ID: "bbb", Title: "Child", Deps: []string{"aaa"}})
+
+	result, err := DepTree(dir, "aaa", false)
+	if err != nil {
+		t.Fatalf("DepTree: %v", err)
+	}
+
+	expected := "aaa Root\n└── bbb Child\n    └── aaa Root (cycle)"
+	if result != expected {
+		t.Errorf("got:\n%s\nwant:\n%s", result, expected)
+	}
+}
+
+func TestDepTreeDedupDefault(t *testing.T) {
+	dir := tempDir(t)
+	EnsureDir(dir)
+
+	// aaa → bbb, aaa → ccc, bbb → ccc (ccc appears in two branches)
+	writeFile(dir, &Ticket{ID: "aaa", Title: "Root", Deps: []string{"bbb", "ccc"}})
+	writeFile(dir, &Ticket{ID: "bbb", Title: "First", Deps: []string{"ccc"}})
+	writeFile(dir, &Ticket{ID: "ccc", Title: "Shared"})
+
+	result, err := DepTree(dir, "aaa", false)
+	if err != nil {
+		t.Fatalf("DepTree: %v", err)
+	}
+
+	// bbb has deeper subtree (depth 1) so comes first; ccc is expanded under bbb
+	// The second ccc (direct dep of aaa) is a dup
+	expected := "aaa Root\n├── bbb First\n│   └── ccc Shared\n└── ccc Shared (dup)"
+	if result != expected {
+		t.Errorf("got:\n%s\nwant:\n%s", result, expected)
+	}
+}
+
+func TestDepTreeFullNoDup(t *testing.T) {
+	dir := tempDir(t)
+	EnsureDir(dir)
+
+	// Same structure as dedup test but with full=true
+	writeFile(dir, &Ticket{ID: "aaa", Title: "Root", Deps: []string{"bbb", "ccc"}})
+	writeFile(dir, &Ticket{ID: "bbb", Title: "First", Deps: []string{"ccc"}})
+	writeFile(dir, &Ticket{ID: "ccc", Title: "Shared"})
+
+	result, err := DepTree(dir, "aaa", true)
+	if err != nil {
+		t.Fatalf("DepTree: %v", err)
+	}
+
+	// In full mode, ccc appears fully in both places (no dup marker)
+	expected := "aaa Root\n├── bbb First\n│   └── ccc Shared\n└── ccc Shared"
+	if result != expected {
+		t.Errorf("got:\n%s\nwant:\n%s", result, expected)
+	}
+}
+
+func TestDepTreeMissingDep(t *testing.T) {
+	dir := tempDir(t)
+	EnsureDir(dir)
+
+	writeFile(dir, &Ticket{ID: "aaa", Title: "Root", Deps: []string{"bbb", "zzz"}})
+	writeFile(dir, &Ticket{ID: "bbb", Title: "Valid"})
+	// "zzz" doesn't exist — should be skipped
+
+	result, err := DepTree(dir, "aaa", false)
+	if err != nil {
+		t.Fatalf("DepTree: %v", err)
+	}
+
+	expected := "aaa Root\n└── bbb Valid"
+	if result != expected {
+		t.Errorf("got:\n%s\nwant:\n%s", result, expected)
+	}
+}

--- a/test/dep_tree.bats
+++ b/test/dep_tree.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "dep tree shows single ticket with no deps" {
+  run todo add "Root ticket"
+  local id
+  id="$(extract_id_from_add "$output")"
+
+  run todo dep tree "${id}"
+  assert_success
+  assert_output --partial "${id}"
+  assert_output --partial "Root ticket"
+}
+
+@test "dep tree shows simple dependency" {
+  run todo add "Root"
+  local root_id
+  root_id="$(extract_id_from_add "$output")"
+
+  run todo add "Child"
+  local child_id
+  child_id="$(extract_id_from_add "$output")"
+
+  run todo dep "${root_id}" "${child_id}"
+
+  run todo dep tree "${root_id}"
+  assert_success
+  assert_output --partial "└── ${child_id}"
+  assert_output --partial "Child"
+}
+
+@test "dep tree shows nested dependencies" {
+  run todo add "Root"
+  local root_id
+  root_id="$(extract_id_from_add "$output")"
+
+  run todo add "Mid"
+  local mid_id
+  mid_id="$(extract_id_from_add "$output")"
+
+  run todo add "Leaf"
+  local leaf_id
+  leaf_id="$(extract_id_from_add "$output")"
+
+  run todo dep "${root_id}" "${mid_id}"
+  run todo dep "${mid_id}" "${leaf_id}"
+
+  run todo dep tree "${root_id}"
+  assert_success
+  assert_output --partial "${root_id}"
+  assert_output --partial "└── ${mid_id}"
+  assert_output --partial "    └── ${leaf_id}"
+}
+
+@test "dep tree handles cycles" {
+  run todo add "A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "B"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  run todo dep "${id_a}" "${id_b}"
+  run todo dep "${id_b}" "${id_a}"
+
+  run todo dep tree "${id_a}"
+  assert_success
+  assert_output --partial "(cycle)"
+}
+
+@test "dep tree deduplicates by default" {
+  run todo add "Root"
+  local root_id
+  root_id="$(extract_id_from_add "$output")"
+
+  run todo add "A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "Shared"
+  local shared_id
+  shared_id="$(extract_id_from_add "$output")"
+
+  run todo dep "${root_id}" "${id_a}"
+  run todo dep "${root_id}" "${shared_id}"
+  run todo dep "${id_a}" "${shared_id}"
+
+  run todo dep tree "${root_id}"
+  assert_success
+  assert_output --partial "(dup)"
+}
+
+@test "dep tree --full disables deduplication" {
+  run todo add "Root"
+  local root_id
+  root_id="$(extract_id_from_add "$output")"
+
+  run todo add "A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "Shared"
+  local shared_id
+  shared_id="$(extract_id_from_add "$output")"
+
+  run todo dep "${root_id}" "${id_a}"
+  run todo dep "${root_id}" "${shared_id}"
+  run todo dep "${id_a}" "${shared_id}"
+
+  run todo dep tree --full "${root_id}"
+  assert_success
+  refute_output --partial "(dup)"
+}
+
+@test "dep tree shows status" {
+  run todo add "Root"
+  local id
+  id="$(extract_id_from_add "$output")"
+
+  run todo start "${id}"
+
+  run todo dep tree "${id}"
+  assert_success
+  assert_output --partial "[in_progress]"
+}
+
+@test "dep tree fails for nonexistent ticket" {
+  run todo dep tree "zzz"
+  assert_failure
+  assert_output --partial "ticket not found"
+}
+
+@test "dep tree supports partial IDs" {
+  run todo add "Root"
+  local root_id
+  root_id="$(extract_id_from_add "$output")"
+
+  local partial="${root_id:0:2}"
+
+  run todo dep tree "${partial}"
+  assert_success
+  assert_output --partial "${root_id}"
+}


### PR DESCRIPTION
Adds `todo dep tree <id>` subcommand to visualize ticket dependency trees with box-drawing characters.

- New `internal/tickets/tree.go`: `DepTree()` public function, `buildTreeNode()` recursive builder with cycle/dedup tracking, `subtreeDepth()` for sorting, `formatTree()`/`formatChildren()`/`formatNodeLine()` for rendering
- New `cmd/dep_tree.go`: Cobra subcommand `tree` under `depCmd` with `--full` flag to disable deduplication
- Tree output uses box-drawing characters (`├── `, `└── `, `│   `) with `[status]` labels when status is set
- Children sorted by subtree depth descending, then ID ascending
- Cycle detection via ancestor tracking with `(cycle)` markers
- Deduplication via visited tracking with `(dup)` markers (disabled by `--full`)
- Missing deps silently skipped
- 8 unit tests in `internal/tickets/tree_test.go` (NoDeps, Simple, Nested, Sorting, Cycle, DedupDefault, FullNoDup, MissingDep)
- 9 integration tests in `test/dep_tree.bats` (basic, nested, cycles, dedup, --full, status display, nonexistent ticket, partial IDs)
- Updated README.md with "Dependency tree" section and CHANGELOG.md with new entry
- All 58 unit tests and 102 bats integration tests pass