### PR TITLE
Add dep cycle command for DFS-based dependency cycle detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `todo dep <id> <dep-id>` — add a dependency between tickets (idempotent, validates both exist)
 - `todo undep <id> <dep-id>` — remove a dependency between tickets (idempotent, validates both exist)
 - `todo dep tree <id>` — display dependency tree with box-drawing characters, `[status]` labels, cycle/dedup markers, and `--full` flag to disable deduplication
+- `todo dep cycle` — DFS-based cycle detection on open (non-closed) tickets, outputs normalized cycles with member details
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,23 @@ todo dep tree aBc --full
 
 The tree uses box-drawing characters (`├── `, `└── `, `│   `) and shows `[status]` when set. Children are sorted by subtree depth (deepest first), then by ID. Cycles are marked with `(cycle)` and duplicate nodes with `(dup)`. Use `--full` to disable deduplication.
 
+#### Cycle detection
+
+```bash
+# Detect dependency cycles among open tickets
+todo dep cycle
+```
+
+Performs DFS-based cycle detection on all non-closed tickets. Each cycle is displayed as a normalized path (rotated so the smallest ID is first) with member details:
+
+```
+Cycle: aBc -> xYz -> aBc
+  aBc [open] Fix login timeout
+  xYz [in_progress] Refactor auth module
+```
+
+Closed tickets are excluded from the analysis. If no cycles are found, the command produces no output.
+
 ### Interactive TUI
 
 ```bash

--- a/cmd/dep_cycle.go
+++ b/cmd/dep_cycle.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/juanibiapina/todo/internal/tickets"
+	"github.com/spf13/cobra"
+)
+
+var depCycleCmd = &cobra.Command{
+	Use:   "cycle",
+	Short: "Detect dependency cycles among open tickets",
+	Long:  `Detect dependency cycles using DFS-based analysis on open (non-closed) tickets. Outputs normalized cycles with member details.`,
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		output, err := tickets.DepCycles(dir)
+		if err != nil {
+			return err
+		}
+
+		if output != "" {
+			fmt.Println(output)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	depCmd.AddCommand(depCycleCmd)
+}

--- a/internal/tickets/cycle.go
+++ b/internal/tickets/cycle.go
@@ -1,0 +1,199 @@
+package tickets
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// DepCycles detects dependency cycles among open (non-closed) tickets.
+// Returns a formatted string of all cycles found, or empty string if none.
+func DepCycles(dir string) (string, error) {
+	allTickets, err := List(dir)
+	if err != nil {
+		return "", err
+	}
+
+	// Build ticket map and adjacency graph, excluding closed tickets
+	ticketMap := make(map[string]*Ticket)
+	for _, t := range allTickets {
+		if t.Status != "closed" {
+			ticketMap[t.ID] = t
+		}
+	}
+
+	cycles := findCycles(ticketMap)
+
+	if len(cycles) == 0 {
+		return "", nil
+	}
+
+	return formatCycles(cycles, ticketMap), nil
+}
+
+// findCycles performs DFS-based cycle detection on the dependency graph.
+// Uses 3-color marking: white (unseen), gray (in current path), black (fully explored).
+// Returns deduplicated, normalized cycles.
+func findCycles(ticketMap map[string]*Ticket) [][]string {
+	const (
+		white = 0
+		gray  = 1
+		black = 2
+	)
+
+	color := make(map[string]int)
+	path := make([]string, 0)
+	var rawCycles [][]string
+
+	var dfs func(id string)
+	dfs = func(id string) {
+		color[id] = gray
+		path = append(path, id)
+
+		t, ok := ticketMap[id]
+		if ok {
+			for _, depID := range t.Deps {
+				// Skip deps that point to closed or non-existent tickets
+				if _, exists := ticketMap[depID]; !exists {
+					continue
+				}
+
+				switch color[depID] {
+				case white:
+					dfs(depID)
+				case gray:
+					// Found a cycle — extract from the gray node to end of path
+					cycle := extractCycle(path, depID)
+					rawCycles = append(rawCycles, cycle)
+				}
+				// black: already fully explored, skip
+			}
+		}
+
+		path = path[:len(path)-1]
+		color[id] = black
+	}
+
+	// Sort IDs for deterministic traversal order
+	var ids []string
+	for id := range ticketMap {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	for _, id := range ids {
+		if color[id] == white {
+			dfs(id)
+		}
+	}
+
+	return deduplicateCycles(rawCycles)
+}
+
+// extractCycle extracts a cycle from the current DFS path.
+// The cycle starts at startID and includes all nodes from there to the end of path.
+func extractCycle(path []string, startID string) []string {
+	for i, id := range path {
+		if id == startID {
+			cycle := make([]string, len(path)-i)
+			copy(cycle, path[i:])
+			return cycle
+		}
+	}
+	return nil
+}
+
+// normalizeCycle rotates a cycle so that the lexicographically smallest ID is first.
+func normalizeCycle(cycle []string) []string {
+	if len(cycle) == 0 {
+		return cycle
+	}
+
+	// Find the index of the smallest ID
+	minIdx := 0
+	for i := 1; i < len(cycle); i++ {
+		if cycle[i] < cycle[minIdx] {
+			minIdx = i
+		}
+	}
+
+	// Rotate so smallest is first
+	normalized := make([]string, len(cycle))
+	for i := 0; i < len(cycle); i++ {
+		normalized[i] = cycle[(minIdx+i)%len(cycle)]
+	}
+	return normalized
+}
+
+// deduplicateCycles normalizes all cycles and removes duplicates.
+// Sorts the result by first element, then by length.
+func deduplicateCycles(rawCycles [][]string) [][]string {
+	seen := make(map[string]bool)
+	var unique [][]string
+
+	for _, cycle := range rawCycles {
+		normalized := normalizeCycle(cycle)
+		key := strings.Join(normalized, ",")
+		if !seen[key] {
+			seen[key] = true
+			unique = append(unique, normalized)
+		}
+	}
+
+	// Sort cycles: by first element, then by length
+	sort.Slice(unique, func(i, j int) bool {
+		if unique[i][0] != unique[j][0] {
+			return unique[i][0] < unique[j][0]
+		}
+		return len(unique[i]) < len(unique[j])
+	})
+
+	return unique
+}
+
+// formatCycles renders all detected cycles as a formatted string.
+func formatCycles(cycles [][]string, ticketMap map[string]*Ticket) string {
+	var b strings.Builder
+
+	for i, cycle := range cycles {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+
+		// Header line: "Cycle: aaa -> bbb -> ccc -> aaa"
+		b.WriteString("Cycle: ")
+		for j, id := range cycle {
+			if j > 0 {
+				b.WriteString(" -> ")
+			}
+			b.WriteString(id)
+		}
+		b.WriteString(" -> ")
+		b.WriteString(cycle[0])
+		b.WriteString("\n")
+
+		// Member details
+		for _, id := range cycle {
+			b.WriteString(formatCycleMember(id, ticketMap))
+		}
+	}
+
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// formatCycleMember renders a single cycle member as "  id [status] Title\n".
+func formatCycleMember(id string, ticketMap map[string]*Ticket) string {
+	t, ok := ticketMap[id]
+	if !ok {
+		return fmt.Sprintf("  %s\n", id)
+	}
+
+	var parts []string
+	parts = append(parts, id)
+	if t.Status != "" {
+		parts = append(parts, fmt.Sprintf("[%s]", t.Status))
+	}
+	parts = append(parts, t.Title)
+
+	return fmt.Sprintf("  %s\n", strings.Join(parts, " "))
+}

--- a/internal/tickets/cycle_test.go
+++ b/internal/tickets/cycle_test.go
@@ -1,0 +1,154 @@
+package tickets
+
+import (
+	"testing"
+)
+
+func TestDepCyclesNoCycles(t *testing.T) {
+	dir := tempDir(t)
+	EnsureDir(dir)
+
+	writeFile(dir, &Ticket{ID: "aaa", Title: "Root", Deps: []string{"bbb"}})
+	writeFile(dir, &Ticket{ID: "bbb", Title: "Child"})
+
+	result, err := DepCycles(dir)
+	if err != nil {
+		t.Fatalf("DepCycles: %v", err)
+	}
+
+	if result != "" {
+		t.Errorf("expected empty string, got:\n%s", result)
+	}
+}
+
+func TestDepCyclesSimple(t *testing.T) {
+	dir := tempDir(t)
+	EnsureDir(dir)
+
+	writeFile(dir, &Ticket{ID: "aaa", Title: "First", Deps: []string{"bbb"}})
+	writeFile(dir, &Ticket{ID: "bbb", Title: "Second", Deps: []string{"aaa"}})
+
+	result, err := DepCycles(dir)
+	if err != nil {
+		t.Fatalf("DepCycles: %v", err)
+	}
+
+	expected := "Cycle: aaa -> bbb -> aaa\n  aaa First\n  bbb Second"
+	if result != expected {
+		t.Errorf("got:\n%s\nwant:\n%s", result, expected)
+	}
+}
+
+func TestDepCyclesThreeNode(t *testing.T) {
+	dir := tempDir(t)
+	EnsureDir(dir)
+
+	writeFile(dir, &Ticket{ID: "aaa", Title: "A", Deps: []string{"bbb"}})
+	writeFile(dir, &Ticket{ID: "bbb", Title: "B", Deps: []string{"ccc"}})
+	writeFile(dir, &Ticket{ID: "ccc", Title: "C", Deps: []string{"aaa"}})
+
+	result, err := DepCycles(dir)
+	if err != nil {
+		t.Fatalf("DepCycles: %v", err)
+	}
+
+	expected := "Cycle: aaa -> bbb -> ccc -> aaa\n  aaa A\n  bbb B\n  ccc C"
+	if result != expected {
+		t.Errorf("got:\n%s\nwant:\n%s", result, expected)
+	}
+}
+
+func TestDepCyclesMultiple(t *testing.T) {
+	dir := tempDir(t)
+	EnsureDir(dir)
+
+	// Two independent cycles: aaa <-> bbb, ccc <-> ddd
+	writeFile(dir, &Ticket{ID: "aaa", Title: "A", Deps: []string{"bbb"}})
+	writeFile(dir, &Ticket{ID: "bbb", Title: "B", Deps: []string{"aaa"}})
+	writeFile(dir, &Ticket{ID: "ccc", Title: "C", Deps: []string{"ddd"}})
+	writeFile(dir, &Ticket{ID: "ddd", Title: "D", Deps: []string{"ccc"}})
+
+	result, err := DepCycles(dir)
+	if err != nil {
+		t.Fatalf("DepCycles: %v", err)
+	}
+
+	expected := "Cycle: aaa -> bbb -> aaa\n  aaa A\n  bbb B\n\nCycle: ccc -> ddd -> ccc\n  ccc C\n  ddd D"
+	if result != expected {
+		t.Errorf("got:\n%s\nwant:\n%s", result, expected)
+	}
+}
+
+func TestDepCyclesClosedExcluded(t *testing.T) {
+	dir := tempDir(t)
+	EnsureDir(dir)
+
+	// aaa -> bbb -> aaa, but bbb is closed — should break the cycle
+	writeFile(dir, &Ticket{ID: "aaa", Title: "Open", Status: "open", Deps: []string{"bbb"}})
+	writeFile(dir, &Ticket{ID: "bbb", Title: "Closed", Status: "closed", Deps: []string{"aaa"}})
+
+	result, err := DepCycles(dir)
+	if err != nil {
+		t.Fatalf("DepCycles: %v", err)
+	}
+
+	if result != "" {
+		t.Errorf("expected no cycles (closed ticket excluded), got:\n%s", result)
+	}
+}
+
+func TestDepCyclesNormalized(t *testing.T) {
+	dir := tempDir(t)
+	EnsureDir(dir)
+
+	// Cycle: ccc -> aaa -> bbb -> ccc
+	// After normalization, should start with aaa
+	writeFile(dir, &Ticket{ID: "ccc", Title: "C", Deps: []string{"aaa"}})
+	writeFile(dir, &Ticket{ID: "aaa", Title: "A", Deps: []string{"bbb"}})
+	writeFile(dir, &Ticket{ID: "bbb", Title: "B", Deps: []string{"ccc"}})
+
+	result, err := DepCycles(dir)
+	if err != nil {
+		t.Fatalf("DepCycles: %v", err)
+	}
+
+	expected := "Cycle: aaa -> bbb -> ccc -> aaa\n  aaa A\n  bbb B\n  ccc C"
+	if result != expected {
+		t.Errorf("got:\n%s\nwant:\n%s", result, expected)
+	}
+}
+
+func TestDepCyclesNoDeps(t *testing.T) {
+	dir := tempDir(t)
+	EnsureDir(dir)
+
+	writeFile(dir, &Ticket{ID: "aaa", Title: "Solo"})
+	writeFile(dir, &Ticket{ID: "bbb", Title: "Also solo"})
+
+	result, err := DepCycles(dir)
+	if err != nil {
+		t.Fatalf("DepCycles: %v", err)
+	}
+
+	if result != "" {
+		t.Errorf("expected empty string, got:\n%s", result)
+	}
+}
+
+func TestDepCyclesWithStatus(t *testing.T) {
+	dir := tempDir(t)
+	EnsureDir(dir)
+
+	writeFile(dir, &Ticket{ID: "aaa", Title: "First", Status: "open", Deps: []string{"bbb"}})
+	writeFile(dir, &Ticket{ID: "bbb", Title: "Second", Status: "in_progress", Deps: []string{"aaa"}})
+
+	result, err := DepCycles(dir)
+	if err != nil {
+		t.Fatalf("DepCycles: %v", err)
+	}
+
+	expected := "Cycle: aaa -> bbb -> aaa\n  aaa [open] First\n  bbb [in_progress] Second"
+	if result != expected {
+		t.Errorf("got:\n%s\nwant:\n%s", result, expected)
+	}
+}

--- a/test/dep_cycle.bats
+++ b/test/dep_cycle.bats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "dep cycle reports no output when no cycles" {
+  run todo add "A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "B"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  run todo dep "${id_a}" "${id_b}"
+
+  run todo dep cycle
+  assert_success
+  assert_output ""
+}
+
+@test "dep cycle detects simple two-node cycle" {
+  run todo add "First"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "Second"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  run todo dep "${id_a}" "${id_b}"
+  run todo dep "${id_b}" "${id_a}"
+
+  run todo dep cycle
+  assert_success
+  assert_output --partial "Cycle:"
+  assert_output --partial "${id_a}"
+  assert_output --partial "${id_b}"
+  assert_output --partial "First"
+  assert_output --partial "Second"
+}
+
+@test "dep cycle detects three-node cycle" {
+  run todo add "A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "B"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  run todo add "C"
+  local id_c
+  id_c="$(extract_id_from_add "$output")"
+
+  run todo dep "${id_a}" "${id_b}"
+  run todo dep "${id_b}" "${id_c}"
+  run todo dep "${id_c}" "${id_a}"
+
+  run todo dep cycle
+  assert_success
+  assert_output --partial "Cycle:"
+  assert_output --partial "${id_a}"
+  assert_output --partial "${id_b}"
+  assert_output --partial "${id_c}"
+}
+
+@test "dep cycle excludes closed tickets" {
+  run todo add "Open"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "Will close"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  run todo dep "${id_a}" "${id_b}"
+  run todo dep "${id_b}" "${id_a}"
+
+  # Close one ticket — should break the cycle
+  run todo close "${id_b}"
+
+  run todo dep cycle
+  assert_success
+  assert_output ""
+}
+
+@test "dep cycle shows status in member details" {
+  run todo add "Started"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "Open"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  run todo start "${id_a}"
+  run todo status "${id_b}" "open"
+
+  run todo dep "${id_a}" "${id_b}"
+  run todo dep "${id_b}" "${id_a}"
+
+  run todo dep cycle
+  assert_success
+  assert_output --partial "[in_progress]"
+  assert_output --partial "[open]"
+}
+
+@test "dep cycle reports no output when no tickets" {
+  run todo dep cycle
+  assert_success
+  assert_output ""
+}
+
+@test "dep cycle reports no output when tickets have no deps" {
+  run todo add "Solo A"
+  run todo add "Solo B"
+
+  run todo dep cycle
+  assert_success
+  assert_output ""
+}


### PR DESCRIPTION
Adds `todo dep cycle` subcommand that detects dependency cycles among open (non-closed) tickets using DFS-based 3-color algorithm.

- Created `internal/tickets/cycle.go` with `DepCycles(dir)` public API, `findCycles()` using 3-color DFS (white/gray/black), `extractCycle()`, `normalizeCycle()`, `deduplicateCycles()`, `formatCycles()`, and `formatCycleMember()`
- Created `cmd/dep_cycle.go` as cobra subcommand `cycle` under `depCmd` with `cobra.NoArgs`
- Cycles normalized by rotating so lexicographically smallest ID is first; deduplicated via string key
- Closed tickets excluded from adjacency graph entirely; deps to closed/non-existent tickets skipped
- Output format: `Cycle: aaa -> bbb -> ccc -> aaa` header with indented member lines `  id [status] Title`; empty output when no cycles
- Created `internal/tickets/cycle_test.go` with 8 unit tests (NoCycles, Simple, ThreeNode, Multiple, ClosedExcluded, Normalized, NoDeps, WithStatus)
- Created `test/dep_cycle.bats` with 7 integration tests (no cycles, 2-node, 3-node, closed exclusion, status display, no tickets, no deps)
- Updated `README.md` with "Cycle detection" subsection and `CHANGELOG.md` with new entry
- All 66 unit tests and 109 bats integration tests pass