### PR TITLE
Add link/unlink commands for bidirectional ticket linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `todo undep <id> <dep-id>` — remove a dependency between tickets (idempotent, validates both exist)
 - `todo dep tree <id>` — display dependency tree with box-drawing characters, `[status]` labels, cycle/dedup markers, and `--full` flag to disable deduplication
 - `todo dep cycle` — DFS-based cycle detection on open (non-closed) tickets, outputs normalized cycles with member details
+- `todo link <id> <id> [id...]` — create bidirectional links between tickets (supports 3+ tickets, idempotent, validates all exist)
+- `todo unlink <id> <target-id>` — remove a bidirectional link between two tickets (idempotent, validates both exist)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,21 @@ Cycle: aBc -> xYz -> aBc
 
 Closed tickets are excluded from the analysis. If no cycles are found, the command produces no output.
 
+### Manage links
+
+```bash
+# Link two tickets bidirectionally (both files updated)
+todo link aBc xYz
+
+# Link three or more tickets (all pairs linked)
+todo link aBc xYz qRs
+
+# Remove a link between two tickets (both sides removed)
+todo unlink aBc xYz
+```
+
+Both commands validate that the referenced tickets exist. Operations are idempotent — adding an existing link or removing a non-existent one succeeds silently. Partial ID matching is supported.
+
 ### Interactive TUI
 
 ```bash

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/juanibiapina/todo/internal/tickets"
+	"github.com/spf13/cobra"
+)
+
+var linkCmd = &cobra.Command{
+	Use:   "link <id> <id> [id...]",
+	Short: "Create bidirectional links between tickets",
+	Long:  `Create bidirectional links between two or more tickets. All tickets are linked to each other. The operation is idempotent.`,
+	Args:  cobra.MinimumNArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		err = tickets.AddLink(dir, args)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Linked tickets: %s\n", strings.Join(args, ", "))
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(linkCmd)
+}

--- a/cmd/unlink.go
+++ b/cmd/unlink.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/juanibiapina/todo/internal/tickets"
+	"github.com/spf13/cobra"
+)
+
+var unlinkCmd = &cobra.Command{
+	Use:   "unlink <id> <target-id>",
+	Short: "Remove a bidirectional link between tickets",
+	Long:  `Remove a bidirectional link between two tickets. The link is removed from both sides. The operation is idempotent.`,
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id := args[0]
+		targetID := args[1]
+
+		dir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		err = tickets.RemoveLink(dir, id, targetID)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Unlinked %s and %s\n", id, targetID)
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(unlinkCmd)
+}

--- a/test/link.bats
+++ b/test/link.bats
@@ -1,0 +1,185 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "link creates bidirectional links" {
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "Ticket B"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  run todo link "${id_a}" "${id_b}"
+  assert_success
+  assert_output "Linked tickets: ${id_a}, ${id_b}"
+
+  # A should link to B
+  run todo show "${id_a}"
+  assert_success
+  assert_output --partial "links:"
+  assert_output --partial "${id_b}"
+
+  # B should link to A
+  run todo show "${id_b}"
+  assert_success
+  assert_output --partial "links:"
+  assert_output --partial "${id_a}"
+}
+
+@test "link supports three or more tickets" {
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "Ticket B"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  run todo add "Ticket C"
+  local id_c
+  id_c="$(extract_id_from_add "$output")"
+
+  run todo link "${id_a}" "${id_b}" "${id_c}"
+  assert_success
+  assert_output "Linked tickets: ${id_a}, ${id_b}, ${id_c}"
+
+  # A should link to B and C
+  run todo show "${id_a}"
+  assert_success
+  assert_output --partial "${id_b}"
+  assert_output --partial "${id_c}"
+
+  # B should link to A and C
+  run todo show "${id_b}"
+  assert_success
+  assert_output --partial "${id_a}"
+  assert_output --partial "${id_c}"
+
+  # C should link to A and B
+  run todo show "${id_c}"
+  assert_success
+  assert_output --partial "${id_a}"
+  assert_output --partial "${id_b}"
+}
+
+@test "link is idempotent" {
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "Ticket B"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  run todo link "${id_a}" "${id_b}"
+  assert_success
+
+  run todo link "${id_a}" "${id_b}"
+  assert_success
+
+  # A should have B only once
+  run todo show "${id_a}"
+  assert_success
+  local count
+  count=$(echo "$output" | grep -c "${id_b}" || true)
+  [ "$count" -eq 1 ]
+}
+
+@test "link fails when ticket does not exist" {
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo link "${id_a}" "zzz"
+  assert_failure
+  assert_output --partial "ticket not found"
+}
+
+@test "link works with partial IDs" {
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "Ticket B"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  # Use first 2 chars as partial IDs
+  local partial_a="${id_a:0:2}"
+  local partial_b="${id_b:0:2}"
+
+  run todo link "${partial_a}" "${partial_b}"
+  assert_success
+
+  # Verify the full resolved IDs are stored
+  run todo show "${id_a}"
+  assert_success
+  assert_output --partial "${id_b}"
+
+  run todo show "${id_b}"
+  assert_success
+  assert_output --partial "${id_a}"
+}
+
+@test "link does not create self-links" {
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "Ticket B"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  run todo link "${id_a}" "${id_b}"
+  assert_success
+
+  # A should not link to itself
+  run todo show "${id_a}"
+  assert_success
+  local count
+  count=$(echo "$output" | grep -c "${id_a}" || true)
+  # id_a appears in the "id:" line but should NOT appear in links
+  [ "$count" -eq 1 ]
+}
+
+@test "link requires at least 2 arguments" {
+  run todo link
+  assert_failure
+
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo link "${id_a}"
+  assert_failure
+}
+
+@test "link preserves existing links" {
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "Ticket B"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  run todo add "Ticket C"
+  local id_c
+  id_c="$(extract_id_from_add "$output")"
+
+  # Link A and B first
+  run todo link "${id_a}" "${id_b}"
+  assert_success
+
+  # Then link A and C
+  run todo link "${id_a}" "${id_c}"
+  assert_success
+
+  # A should have both B and C
+  run todo show "${id_a}"
+  assert_success
+  assert_output --partial "${id_b}"
+  assert_output --partial "${id_c}"
+}

--- a/test/unlink.bats
+++ b/test/unlink.bats
@@ -1,0 +1,124 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "unlink removes bidirectional link" {
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "Ticket B"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  run todo link "${id_a}" "${id_b}"
+  assert_success
+
+  run todo unlink "${id_a}" "${id_b}"
+  assert_success
+  assert_output "Unlinked ${id_a} and ${id_b}"
+
+  # Neither should have links
+  run todo show "${id_a}"
+  assert_success
+  refute_output --partial "links:"
+
+  run todo show "${id_b}"
+  assert_success
+  refute_output --partial "links:"
+}
+
+@test "unlink is idempotent" {
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "Ticket B"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  # Unlink tickets that were never linked — should succeed
+  run todo unlink "${id_a}" "${id_b}"
+  assert_success
+}
+
+@test "unlink fails when ticket does not exist" {
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo unlink "${id_a}" "zzz"
+  assert_failure
+  assert_output --partial "ticket not found"
+}
+
+@test "unlink works with partial IDs" {
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "Ticket B"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  run todo link "${id_a}" "${id_b}"
+  assert_success
+
+  # Use first 2 chars as partial IDs
+  local partial_a="${id_a:0:2}"
+  local partial_b="${id_b:0:2}"
+
+  run todo unlink "${partial_a}" "${partial_b}"
+  assert_success
+
+  # Verify links are removed from both
+  run todo show "${id_a}"
+  assert_success
+  refute_output --partial "links:"
+
+  run todo show "${id_b}"
+  assert_success
+  refute_output --partial "links:"
+}
+
+@test "unlink only removes the specified link" {
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo add "Ticket B"
+  local id_b
+  id_b="$(extract_id_from_add "$output")"
+
+  run todo add "Ticket C"
+  local id_c
+  id_c="$(extract_id_from_add "$output")"
+
+  # Link A to both B and C
+  run todo link "${id_a}" "${id_b}"
+  assert_success
+  run todo link "${id_a}" "${id_c}"
+  assert_success
+
+  # Unlink A and B only
+  run todo unlink "${id_a}" "${id_b}"
+  assert_success
+
+  # A should still link to C
+  run todo show "${id_a}"
+  assert_success
+  assert_output --partial "${id_c}"
+  refute_output --partial "- ${id_b}"
+}
+
+@test "unlink requires exactly 2 arguments" {
+  run todo unlink
+  assert_failure
+
+  run todo add "Ticket A"
+  local id_a
+  id_a="$(extract_id_from_add "$output")"
+
+  run todo unlink "${id_a}"
+  assert_failure
+}


### PR DESCRIPTION
Adds `link` and `unlink` commands for bidirectional linking between tickets. Unlike `dep` (one-directional), `link` is symmetric — linking A↔B updates both ticket files. Supports 3+ tickets in a single `link` call (all pairs linked).

- Add `AddLink(dir string, ids []string) error` in `internal/tickets/file.go` — resolves partial IDs, links all pairs bidirectionally, idempotent (skips duplicates)
- Add `RemoveLink(dir string, id string, targetID string) error` in `internal/tickets/file.go` — removes link from both sides, idempotent (no error if link absent)
- Create `cmd/link.go` — cobra command `link <id> <id> [id...]` with `MinimumNArgs(2)`, outputs "Linked tickets: id1, id2, ..."
- Create `cmd/unlink.go` — cobra command `unlink <id> <target-id>` with `ExactArgs(2)`, outputs "Unlinked %s and %s"
- Add 7 unit tests in `internal/tickets/file_test.go`: TestAddLink, TestAddLinkThreeTickets, TestAddLinkIdempotent, TestAddLinkTicketNotFound, TestRemoveLink, TestRemoveLinkIdempotent, TestRemoveLinkTicketNotFound
- Create `test/link.bats` with 8 integration tests (bidirectional, 3+ tickets, idempotency, not-found, partial IDs, no self-links, arg validation, preserving existing links)
- Create `test/unlink.bats` with 6 integration tests (bidirectional removal, idempotency, not-found, partial IDs, selective removal, arg validation)
- Update README.md with "Manage links" section and CHANGELOG.md with new entries

All 73 unit tests and 123 bats integration tests pass.