### PR TITLE
Add ready command to show actionable tickets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `todo link <id> <id> [id...]` — create bidirectional links between tickets (supports 3+ tickets, idempotent, validates all exist)
 - `todo unlink <id> <target-id>` — remove a bidirectional link between two tickets (idempotent, validates both exist)
 - `todo list` flags: `--status` (filter by status), `-a/--assignee` (filter by assignee), `-T/--tag` (filter by tag) — filters combine with AND logic
+- `todo ready` — show tickets ready to work on (open/in_progress with all deps closed or no deps), sorted by priority then ID, with `-a/--assignee` and `-T/--tag` filters
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,35 @@ Cycle: aBc -> xYz -> aBc
 
 Closed tickets are excluded from the analysis. If no cycles are found, the command produces no output.
 
+### Ready tickets
+
+```bash
+todo ready
+# aBc [P1][open] - Critical bug fix
+# xYz [P2][in_progress] - Refactor auth module
+```
+
+Shows tickets that are ready to work on: open or in-progress tickets where all dependencies are closed (or have no dependencies). Missing deps are treated as non-blocking.
+
+Output format: `id [P<priority>][status] - Title`. Priority is always shown. Empty status is displayed as `[open]`. Tickets are sorted by priority ascending (lower number = higher priority), then by ID.
+
+Filter by assignee or tag:
+
+```bash
+# Filter by assignee
+todo ready -a Alice
+
+# Filter by tag
+todo ready -T urgent
+```
+
+**Flags:**
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--assignee` | `-a` | Filter by assignee |
+| `--tag` | `-T` | Filter by tag |
+
 ### Manage links
 
 ```bash

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -17,6 +17,24 @@ func cliID(id string) string {
 	return cliMagenta.Render(id)
 }
 
+func formatReadyLine(t *tickets.Ticket) string {
+	var b strings.Builder
+
+	b.WriteString(cliID(t.ID))
+	b.WriteString(fmt.Sprintf(" [P%d]", t.Priority))
+
+	status := t.Status
+	if status == "" {
+		status = "open"
+	}
+	b.WriteString(fmt.Sprintf("[%s]", status))
+
+	b.WriteString(" - ")
+	b.WriteString(t.Title)
+
+	return b.String()
+}
+
 func formatTicketLine(t *tickets.Ticket) string {
 	var b strings.Builder
 

--- a/cmd/ready.go
+++ b/cmd/ready.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/juanibiapina/todo/internal/tickets"
+	"github.com/spf13/cobra"
+)
+
+var readyCmd = &cobra.Command{
+	Use:   "ready",
+	Short: "Show tickets ready to work on",
+	Long:  `Show open/in_progress tickets with all deps closed or no deps, sorted by priority then ID.`,
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		allItems, err := tickets.List(dir)
+		if err != nil {
+			return err
+		}
+
+		// Build a map of ticket ID -> status for dep checking
+		statusMap := make(map[string]string)
+		for _, t := range allItems {
+			statusMap[t.ID] = t.Status
+		}
+
+		assigneeFilter, _ := cmd.Flags().GetString("assignee")
+		tagFilter, _ := cmd.Flags().GetString("tag")
+
+		var ready []*tickets.Ticket
+		for _, t := range allItems {
+			// Only open/in_progress tickets (not closed)
+			if t.Status == "closed" {
+				continue
+			}
+
+			// Check all deps are closed or missing (non-blocking)
+			allDepsDone := true
+			for _, depID := range t.Deps {
+				depStatus, exists := statusMap[depID]
+				if exists && depStatus != "closed" {
+					allDepsDone = false
+					break
+				}
+				// Missing deps treated as non-blocking
+			}
+			if !allDepsDone {
+				continue
+			}
+
+			// Apply --assignee filter
+			if assigneeFilter != "" && t.Assignee != assigneeFilter {
+				continue
+			}
+
+			// Apply --tag filter
+			if tagFilter != "" {
+				found := false
+				for _, tag := range t.Tags {
+					if tag == tagFilter {
+						found = true
+						break
+					}
+				}
+				if !found {
+					continue
+				}
+			}
+
+			ready = append(ready, t)
+		}
+
+		// Sort by priority ascending, then by ID ascending
+		sort.Slice(ready, func(i, j int) bool {
+			if ready[i].Priority != ready[j].Priority {
+				return ready[i].Priority < ready[j].Priority
+			}
+			return ready[i].ID < ready[j].ID
+		})
+
+		for _, t := range ready {
+			fmt.Println(formatReadyLine(t))
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	readyCmd.Flags().StringP("assignee", "a", "", "Filter by assignee")
+	readyCmd.Flags().StringP("tag", "T", "", "Filter by tag")
+	rootCmd.AddCommand(readyCmd)
+}

--- a/test/ready.bats
+++ b/test/ready.bats
@@ -1,0 +1,146 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "ready: empty list returns no output" {
+  run todo ready
+  assert_success
+  assert_output ""
+}
+
+@test "ready: shows ticket with no deps" {
+  todo add "No deps ticket"
+
+  run todo ready
+  assert_success
+  assert_output --partial "No deps ticket"
+}
+
+@test "ready: shows ticket when all deps are closed" {
+  local out1 out2
+  out1="$(todo add "Dep ticket")"
+  out2="$(todo add "Main ticket")"
+  local id1 id2
+  id1="$(extract_id_from_add "${out1}")"
+  id2="$(extract_id_from_add "${out2}")"
+
+  todo dep "${id2}" "${id1}"
+  todo close "${id1}"
+
+  run todo ready
+  assert_success
+  assert_output --partial "Main ticket"
+}
+
+@test "ready: hides ticket with unclosed deps" {
+  local out1 out2
+  out1="$(todo add "Blocker")"
+  out2="$(todo add "Blocked ticket")"
+  local id1 id2
+  id1="$(extract_id_from_add "${out1}")"
+  id2="$(extract_id_from_add "${out2}")"
+
+  todo dep "${id2}" "${id1}"
+
+  run todo ready
+  assert_success
+  # Blocked ticket should NOT appear (has unclosed dep)
+  refute_output --partial "Blocked ticket"
+  # Blocker itself has no deps, so it should appear
+  assert_output --partial "Blocker"
+}
+
+@test "ready: hides closed tickets" {
+  local out
+  out="$(todo add "Closed ticket")"
+  local id
+  id="$(extract_id_from_add "${out}")"
+
+  todo close "${id}"
+
+  run todo ready
+  assert_success
+  refute_output --partial "Closed ticket"
+}
+
+@test "ready: shows in_progress tickets" {
+  local out
+  out="$(todo add "In progress ticket")"
+  local id
+  id="$(extract_id_from_add "${out}")"
+
+  todo start "${id}"
+
+  run todo ready
+  assert_success
+  assert_output --partial "In progress ticket"
+  assert_output --partial "[in_progress]"
+}
+
+@test "ready: sorted by priority ascending then ID" {
+  local out1 out2 out3
+  out1="$(todo add "Low priority" -p 4)"
+  out2="$(todo add "High priority" -p 0)"
+  out3="$(todo add "Medium priority" -p 2)"
+
+  run todo ready
+  assert_success
+
+  # All three should appear
+  assert_output --partial "High priority"
+  assert_output --partial "Medium priority"
+  assert_output --partial "Low priority"
+
+  # Check ordering: high priority (P0) should come before medium (P2) before low (P4)
+  local line1 line2 line3
+  line1="$(echo "${output}" | sed -n '1p')"
+  line2="$(echo "${output}" | sed -n '2p')"
+  line3="$(echo "${output}" | sed -n '3p')"
+
+  [[ "${line1}" == *"[P0]"* ]]
+  [[ "${line2}" == *"[P2]"* ]]
+  [[ "${line3}" == *"[P4]"* ]]
+}
+
+@test "ready: output format shows priority and status" {
+  local out
+  out="$(todo add "Format test" -p 3)"
+  local id
+  id="$(extract_id_from_add "${out}")"
+
+  run todo ready
+  assert_success
+  assert_output --partial "[P3]"
+  assert_output --partial "[open]"
+  assert_output --partial "- Format test"
+}
+
+@test "ready: -a filters by assignee" {
+  todo add "Alice task" -a alice
+  todo add "Bob task" -a bob
+
+  run todo ready -a alice
+  assert_success
+  assert_output --partial "Alice task"
+  refute_output --partial "Bob task"
+}
+
+@test "ready: -T filters by tag" {
+  todo add "Backend task" --tags "backend,urgent"
+  todo add "Frontend task" --tags "frontend"
+
+  run todo ready -T backend
+  assert_success
+  assert_output --partial "Backend task"
+  refute_output --partial "Frontend task"
+}
+
+@test "ready: empty status displayed as open" {
+  # New tickets have empty status, should show as [open]
+  todo add "New ticket"
+
+  run todo ready
+  assert_success
+  assert_output --partial "[open]"
+  refute_output --partial "[]"
+}


### PR DESCRIPTION
Adds `todo ready` command that lists actionable tickets — open or in-progress tickets whose dependencies are all closed (or absent). Sorted by priority ascending, then ID ascending.

- Added `formatReadyLine()` to `cmd/format.go` — output format: `id [P<priority>][status] - Title`, empty status displayed as `[open]`
- Created `cmd/ready.go` — loads all tickets, builds status map, filters to ready tickets (non-closed with all deps closed/missing), supports `-a/--assignee` and `-T/--tag` filter flags with AND logic
- Created `test/ready.bats` with 11 integration tests: empty list, no deps, all deps closed, unclosed deps hidden, closed tickets hidden, in_progress shown, sort order, output format, assignee filter, tag filter, empty status as `[open]`
- Updated `README.md` with "Ready tickets" section including usage examples, output format, and flags table
- Updated `CHANGELOG.md` with entry for `todo ready` command

All 73 unit tests and 150 bats integration tests pass.