### PR TITLE
Add blocked command to show tickets with unclosed dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `todo unlink <id> <target-id>` — remove a bidirectional link between two tickets (idempotent, validates both exist)
 - `todo list` flags: `--status` (filter by status), `-a/--assignee` (filter by assignee), `-T/--tag` (filter by tag) — filters combine with AND logic
 - `todo ready` — show tickets ready to work on (open/in_progress with all deps closed or no deps), sorted by priority then ID, with `-a/--assignee` and `-T/--tag` filters
+- `todo blocked` — show tickets blocked by unclosed dependencies (open/in_progress with ≥1 unclosed dep), sorted by priority then ID, with `-a/--assignee` and `-T/--tag` filters
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,35 @@ todo ready -T urgent
 | `--assignee` | `-a` | Filter by assignee |
 | `--tag` | `-T` | Filter by tag |
 
+### Blocked tickets
+
+```bash
+todo blocked
+# aBc [P1][open] - Critical bug fix <- [xYz]
+# mNp [P2][in_progress] - Refactor auth module <- [qRs, jKl]
+```
+
+Shows tickets that are blocked: open or in-progress tickets with at least one unclosed dependency. Only the unclosed blockers are shown in the output. Missing deps (not found in the ticket list) are treated as non-blocking.
+
+Output format: `id [P<priority>][status] - Title <- [blocker1, blocker2]`. Priority is always shown. Empty status is displayed as `[open]`. Tickets are sorted by priority ascending (lower number = higher priority), then by ID.
+
+Filter by assignee or tag:
+
+```bash
+# Filter by assignee
+todo blocked -a Alice
+
+# Filter by tag
+todo blocked -T urgent
+```
+
+**Flags:**
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--assignee` | `-a` | Filter by assignee |
+| `--tag` | `-T` | Filter by tag |
+
 ### Manage links
 
 ```bash

--- a/cmd/blocked.go
+++ b/cmd/blocked.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/juanibiapina/todo/internal/tickets"
+	"github.com/spf13/cobra"
+)
+
+var blockedCmd = &cobra.Command{
+	Use:   "blocked",
+	Short: "Show tickets blocked by unclosed dependencies",
+	Long:  `Show open/in_progress tickets that have at least one unclosed dependency, sorted by priority then ID.`,
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		allItems, err := tickets.List(dir)
+		if err != nil {
+			return err
+		}
+
+		// Build a map of ticket ID -> status for dep checking
+		statusMap := make(map[string]string)
+		for _, t := range allItems {
+			statusMap[t.ID] = t.Status
+		}
+
+		assigneeFilter, _ := cmd.Flags().GetString("assignee")
+		tagFilter, _ := cmd.Flags().GetString("tag")
+
+		type blockedTicket struct {
+			ticket           *tickets.Ticket
+			unclosedBlockers []string
+		}
+
+		var blocked []blockedTicket
+		for _, t := range allItems {
+			// Only open/in_progress tickets (not closed)
+			if t.Status == "closed" {
+				continue
+			}
+
+			// Find unclosed deps
+			var unclosed []string
+			for _, depID := range t.Deps {
+				depStatus, exists := statusMap[depID]
+				if exists && depStatus != "closed" {
+					unclosed = append(unclosed, depID)
+				}
+				// Missing deps treated as non-blocking
+			}
+
+			// Must have at least one unclosed dep to be "blocked"
+			if len(unclosed) == 0 {
+				continue
+			}
+
+			// Apply --assignee filter
+			if assigneeFilter != "" && t.Assignee != assigneeFilter {
+				continue
+			}
+
+			// Apply --tag filter
+			if tagFilter != "" {
+				found := false
+				for _, tag := range t.Tags {
+					if tag == tagFilter {
+						found = true
+						break
+					}
+				}
+				if !found {
+					continue
+				}
+			}
+
+			blocked = append(blocked, blockedTicket{ticket: t, unclosedBlockers: unclosed})
+		}
+
+		// Sort by priority ascending, then by ID ascending
+		sort.Slice(blocked, func(i, j int) bool {
+			if blocked[i].ticket.Priority != blocked[j].ticket.Priority {
+				return blocked[i].ticket.Priority < blocked[j].ticket.Priority
+			}
+			return blocked[i].ticket.ID < blocked[j].ticket.ID
+		})
+
+		for _, bt := range blocked {
+			fmt.Println(formatBlockedLine(bt.ticket, bt.unclosedBlockers))
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	blockedCmd.Flags().StringP("assignee", "a", "", "Filter by assignee")
+	blockedCmd.Flags().StringP("tag", "T", "", "Filter by tag")
+	rootCmd.AddCommand(blockedCmd)
+}

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -35,6 +35,30 @@ func formatReadyLine(t *tickets.Ticket) string {
 	return b.String()
 }
 
+func formatBlockedLine(t *tickets.Ticket, unclosedBlockers []string) string {
+	var b strings.Builder
+
+	b.WriteString(cliID(t.ID))
+	b.WriteString(fmt.Sprintf(" [P%d]", t.Priority))
+
+	status := t.Status
+	if status == "" {
+		status = "open"
+	}
+	b.WriteString(fmt.Sprintf("[%s]", status))
+
+	b.WriteString(" - ")
+	b.WriteString(t.Title)
+
+	if len(unclosedBlockers) > 0 {
+		b.WriteString(" <- [")
+		b.WriteString(strings.Join(unclosedBlockers, ", "))
+		b.WriteString("]")
+	}
+
+	return b.String()
+}
+
 func formatTicketLine(t *tickets.Ticket) string {
 	var b strings.Builder
 

--- a/test/blocked.bats
+++ b/test/blocked.bats
@@ -1,0 +1,200 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "blocked: empty list returns no output" {
+  run todo blocked
+  assert_success
+  assert_output ""
+}
+
+@test "blocked: ticket with no deps is not blocked" {
+  todo add "No deps ticket"
+
+  run todo blocked
+  assert_success
+  assert_output ""
+}
+
+@test "blocked: shows ticket with unclosed dep" {
+  local out1 out2
+  out1="$(todo add "Blocker")"
+  out2="$(todo add "Blocked ticket")"
+  local id1 id2
+  id1="$(extract_id_from_add "${out1}")"
+  id2="$(extract_id_from_add "${out2}")"
+
+  todo dep "${id2}" "${id1}"
+
+  run todo blocked
+  assert_success
+  assert_output --partial "Blocked ticket"
+  # Only one line of output — the blocker itself has no deps so it's not blocked
+  local line_count
+  line_count="$(echo "${output}" | wc -l | tr -d ' ')"
+  [[ "${line_count}" -eq 1 ]]
+}
+
+@test "blocked: hides ticket when all deps are closed" {
+  local out1 out2
+  out1="$(todo add "Dep ticket")"
+  out2="$(todo add "Main ticket")"
+  local id1 id2
+  id1="$(extract_id_from_add "${out1}")"
+  id2="$(extract_id_from_add "${out2}")"
+
+  todo dep "${id2}" "${id1}"
+  todo close "${id1}"
+
+  run todo blocked
+  assert_success
+  # Main ticket has all deps closed, so it should not be blocked
+  assert_output ""
+}
+
+@test "blocked: only shows unclosed blockers in output" {
+  local out1 out2 out3
+  out1="$(todo add "Closed dep")"
+  out2="$(todo add "Open dep")"
+  out3="$(todo add "Blocked ticket")"
+  local id1 id2 id3
+  id1="$(extract_id_from_add "${out1}")"
+  id2="$(extract_id_from_add "${out2}")"
+  id3="$(extract_id_from_add "${out3}")"
+
+  todo dep "${id3}" "${id1}"
+  todo dep "${id3}" "${id2}"
+  todo close "${id1}"
+
+  run todo blocked
+  assert_success
+  assert_output --partial "Blocked ticket"
+  # Only the open dep should be shown as a blocker
+  assert_output --partial "${id2}"
+  refute_output --partial "${id1}"
+}
+
+@test "blocked: hides closed tickets" {
+  local out1 out2
+  out1="$(todo add "Dep")"
+  out2="$(todo add "Ticket to close")"
+  local id1 id2
+  id1="$(extract_id_from_add "${out1}")"
+  id2="$(extract_id_from_add "${out2}")"
+
+  todo dep "${id2}" "${id1}"
+  todo close "${id2}"
+
+  run todo blocked
+  assert_success
+  # Closed ticket should not appear even if it has unclosed deps
+  refute_output --partial "Ticket to close"
+}
+
+@test "blocked: shows in_progress tickets" {
+  local out1 out2
+  out1="$(todo add "Blocker")"
+  out2="$(todo add "In progress blocked")"
+  local id1 id2
+  id1="$(extract_id_from_add "${out1}")"
+  id2="$(extract_id_from_add "${out2}")"
+
+  todo dep "${id2}" "${id1}"
+  todo start "${id2}"
+
+  run todo blocked
+  assert_success
+  assert_output --partial "In progress blocked"
+  assert_output --partial "[in_progress]"
+}
+
+@test "blocked: sorted by priority ascending then ID" {
+  local out_blocker out1 out2 out3
+  out_blocker="$(todo add "Common blocker")"
+  out1="$(todo add "Low priority" -p 4)"
+  out2="$(todo add "High priority" -p 0)"
+  out3="$(todo add "Medium priority" -p 2)"
+  local blocker_id id1 id2 id3
+  blocker_id="$(extract_id_from_add "${out_blocker}")"
+  id1="$(extract_id_from_add "${out1}")"
+  id2="$(extract_id_from_add "${out2}")"
+  id3="$(extract_id_from_add "${out3}")"
+
+  todo dep "${id1}" "${blocker_id}"
+  todo dep "${id2}" "${blocker_id}"
+  todo dep "${id3}" "${blocker_id}"
+
+  run todo blocked
+  assert_success
+
+  # All three should appear
+  assert_output --partial "High priority"
+  assert_output --partial "Medium priority"
+  assert_output --partial "Low priority"
+
+  # Check ordering: P0 before P2 before P4
+  local line1 line2 line3
+  line1="$(echo "${output}" | sed -n '1p')"
+  line2="$(echo "${output}" | sed -n '2p')"
+  line3="$(echo "${output}" | sed -n '3p')"
+
+  [[ "${line1}" == *"[P0]"* ]]
+  [[ "${line2}" == *"[P2]"* ]]
+  [[ "${line3}" == *"[P4]"* ]]
+}
+
+@test "blocked: output format shows priority status and blockers" {
+  local out1 out2
+  out1="$(todo add "Blocker task")"
+  out2="$(todo add "Format test" -p 3)"
+  local id1 id2
+  id1="$(extract_id_from_add "${out1}")"
+  id2="$(extract_id_from_add "${out2}")"
+
+  todo dep "${id2}" "${id1}"
+
+  run todo blocked
+  assert_success
+  assert_output --partial "[P3]"
+  assert_output --partial "[open]"
+  assert_output --partial "- Format test"
+  assert_output --partial "<- [${id1}]"
+}
+
+@test "blocked: -a filters by assignee" {
+  local out_blocker out1 out2
+  out_blocker="$(todo add "Blocker")"
+  out1="$(todo add "Alice task" -a alice)"
+  out2="$(todo add "Bob task" -a bob)"
+  local blocker_id id1 id2
+  blocker_id="$(extract_id_from_add "${out_blocker}")"
+  id1="$(extract_id_from_add "${out1}")"
+  id2="$(extract_id_from_add "${out2}")"
+
+  todo dep "${id1}" "${blocker_id}"
+  todo dep "${id2}" "${blocker_id}"
+
+  run todo blocked -a alice
+  assert_success
+  assert_output --partial "Alice task"
+  refute_output --partial "Bob task"
+}
+
+@test "blocked: -T filters by tag" {
+  local out_blocker out1 out2
+  out_blocker="$(todo add "Blocker")"
+  out1="$(todo add "Backend task" --tags "backend,urgent")"
+  out2="$(todo add "Frontend task" --tags "frontend")"
+  local blocker_id id1 id2
+  blocker_id="$(extract_id_from_add "${out_blocker}")"
+  id1="$(extract_id_from_add "${out1}")"
+  id2="$(extract_id_from_add "${out2}")"
+
+  todo dep "${id1}" "${blocker_id}"
+  todo dep "${id2}" "${blocker_id}"
+
+  run todo blocked -T backend
+  assert_success
+  assert_output --partial "Backend task"
+  refute_output --partial "Frontend task"
+}


### PR DESCRIPTION
Adds `todo blocked` command that lists open/in_progress tickets with at least one unclosed dependency, helping identify what's waiting on other work.

- Add `formatBlockedLine(t, unclosedBlockers)` to `cmd/format.go` — output format: `id [P<priority>][status] - Title <- [blocker1, blocker2]`
- Create `cmd/blocked.go` — cobra command with `cobra.NoArgs`, builds statusMap, filters open/in_progress tickets with unclosed deps, sorts by priority ascending then ID ascending
- Support `-a/--assignee` and `-T/--tag` filter flags (AND logic), matching `ready` command pattern
- Missing deps (not found in ticket list) treated as non-blocking
- Create `test/blocked.bats` with 11 integration tests covering: empty list, no deps, unclosed dep shown, all deps closed hidden, only unclosed blockers in output, closed tickets hidden, in_progress shown, sort order, output format, assignee filter, tag filter
- Update `README.md` with "Blocked tickets" section documenting usage, output format, sorting, and flags
- Update `CHANGELOG.md` with new entry under `[Unreleased] > Added`
- All 73 unit tests and 161 bats integration tests pass
