### PR TITLE
Add closed command to show recently closed tickets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `todo list` flags: `--status` (filter by status), `-a/--assignee` (filter by assignee), `-T/--tag` (filter by tag) — filters combine with AND logic
 - `todo ready` — show tickets ready to work on (open/in_progress with all deps closed or no deps), sorted by priority then ID, with `-a/--assignee` and `-T/--tag` filters
 - `todo blocked` — show tickets blocked by unclosed dependencies (open/in_progress with ≥1 unclosed dep), sorted by priority then ID, with `-a/--assignee` and `-T/--tag` filters
+- `todo closed` — show recently closed tickets sorted by file modification time (most recent first), with `--limit`/`-n` (default 20), `-a/--assignee`, and `-T/--tag` filters
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,38 @@ todo blocked -T urgent
 | `--assignee` | `-a` | Filter by assignee |
 | `--tag` | `-T` | Filter by tag |
 
+### Closed tickets
+
+```bash
+todo closed
+# xYz - Completed login fix
+# aBc - Old feature request
+```
+
+Shows recently closed tickets sorted by file modification time (most recent first). Default limit is 20.
+
+Output format: `id - Title`. Status is omitted since all displayed tickets are closed.
+
+```bash
+# Limit the number of results
+todo closed --limit 10
+todo closed -n 5
+
+# Filter by assignee
+todo closed -a Alice
+
+# Filter by tag
+todo closed -T backend
+```
+
+**Flags:**
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--limit` | `-n` | `20` | Maximum number of tickets to show |
+| `--assignee` | `-a` | | Filter by assignee |
+| `--tag` | `-T` | | Filter by tag |
+
 ### Manage links
 
 ```bash

--- a/cmd/closed.go
+++ b/cmd/closed.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/juanibiapina/todo/internal/tickets"
+	"github.com/spf13/cobra"
+)
+
+var closedCmd = &cobra.Command{
+	Use:   "closed",
+	Short: "Show recently closed tickets",
+	Long:  `Show closed tickets sorted by file modification time (most recent first), with an optional limit.`,
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		allItems, err := tickets.List(dir)
+		if err != nil {
+			return err
+		}
+
+		assigneeFilter, _ := cmd.Flags().GetString("assignee")
+		tagFilter, _ := cmd.Flags().GetString("tag")
+		limit, _ := cmd.Flags().GetInt("limit")
+
+		type closedTicket struct {
+			ticket *tickets.Ticket
+			mtime  int64
+		}
+
+		var closed []closedTicket
+		for _, t := range allItems {
+			// Only closed tickets
+			if t.Status != "closed" {
+				continue
+			}
+
+			// Apply --assignee filter
+			if assigneeFilter != "" && t.Assignee != assigneeFilter {
+				continue
+			}
+
+			// Apply --tag filter
+			if tagFilter != "" {
+				found := false
+				for _, tag := range t.Tags {
+					if tag == tagFilter {
+						found = true
+						break
+					}
+				}
+				if !found {
+					continue
+				}
+			}
+
+			// Stat the file for mtime
+			path := filepath.Join(tickets.DirPath(dir), t.ID+".md")
+			info, err := os.Stat(path)
+			if err != nil {
+				continue // skip if stat fails
+			}
+
+			closed = append(closed, closedTicket{ticket: t, mtime: info.ModTime().UnixNano()})
+		}
+
+		// Sort by mtime descending (most recently modified first)
+		sort.Slice(closed, func(i, j int) bool {
+			return closed[i].mtime > closed[j].mtime
+		})
+
+		// Apply limit
+		if limit > 0 && len(closed) > limit {
+			closed = closed[:limit]
+		}
+
+		for _, ct := range closed {
+			fmt.Println(formatClosedLine(ct.ticket))
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	closedCmd.Flags().IntP("limit", "n", 20, "Maximum number of tickets to show")
+	closedCmd.Flags().StringP("assignee", "a", "", "Filter by assignee")
+	closedCmd.Flags().StringP("tag", "T", "", "Filter by tag")
+	rootCmd.AddCommand(closedCmd)
+}

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -59,6 +59,16 @@ func formatBlockedLine(t *tickets.Ticket, unclosedBlockers []string) string {
 	return b.String()
 }
 
+func formatClosedLine(t *tickets.Ticket) string {
+	var b strings.Builder
+
+	b.WriteString(cliID(t.ID))
+	b.WriteString(" - ")
+	b.WriteString(t.Title)
+
+	return b.String()
+}
+
 func formatTicketLine(t *tickets.Ticket) string {
 	var b strings.Builder
 

--- a/test/closed.bats
+++ b/test/closed.bats
@@ -1,0 +1,189 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "closed: empty list returns no output" {
+  run todo closed
+  assert_success
+  assert_output ""
+}
+
+@test "closed: shows closed tickets" {
+  local out
+  out="$(todo add "Closed ticket")"
+  local id
+  id="$(extract_id_from_add "${out}")"
+
+  todo close "${id}"
+
+  run todo closed
+  assert_success
+  assert_output --partial "Closed ticket"
+}
+
+@test "closed: hides open tickets" {
+  todo add "Open ticket"
+
+  run todo closed
+  assert_success
+  assert_output ""
+}
+
+@test "closed: hides in_progress tickets" {
+  local out
+  out="$(todo add "Started ticket")"
+  local id
+  id="$(extract_id_from_add "${out}")"
+
+  todo start "${id}"
+
+  run todo closed
+  assert_success
+  assert_output ""
+}
+
+@test "closed: sorted by mtime descending" {
+  local out1 out2 out3
+  out1="$(todo add "First closed")"
+  out2="$(todo add "Second closed")"
+  out3="$(todo add "Third closed")"
+  local id1 id2 id3
+  id1="$(extract_id_from_add "${out1}")"
+  id2="$(extract_id_from_add "${out2}")"
+  id3="$(extract_id_from_add "${out3}")"
+
+  # Close in order, using touch to set specific mtimes
+  todo close "${id1}"
+  touch -t 202501010100 "${TODO_TEST_DIR}/docs/tickets/${id1}.md"
+
+  todo close "${id2}"
+  touch -t 202501010200 "${TODO_TEST_DIR}/docs/tickets/${id2}.md"
+
+  todo close "${id3}"
+  touch -t 202501010300 "${TODO_TEST_DIR}/docs/tickets/${id3}.md"
+
+  run todo closed
+  assert_success
+
+  # Most recent (id3) should be first, oldest (id1) last
+  local line1 line2 line3
+  line1="$(echo "${output}" | sed -n '1p')"
+  line2="$(echo "${output}" | sed -n '2p')"
+  line3="$(echo "${output}" | sed -n '3p')"
+
+  [[ "${line1}" == *"Third closed"* ]]
+  [[ "${line2}" == *"Second closed"* ]]
+  [[ "${line3}" == *"First closed"* ]]
+}
+
+@test "closed: --limit restricts output count" {
+  local out1 out2 out3
+  out1="$(todo add "Ticket A")"
+  out2="$(todo add "Ticket B")"
+  out3="$(todo add "Ticket C")"
+  local id1 id2 id3
+  id1="$(extract_id_from_add "${out1}")"
+  id2="$(extract_id_from_add "${out2}")"
+  id3="$(extract_id_from_add "${out3}")"
+
+  todo close "${id1}"
+  todo close "${id2}"
+  todo close "${id3}"
+
+  run todo closed --limit 2
+  assert_success
+  local line_count
+  line_count="$(echo "${output}" | wc -l | tr -d ' ')"
+  [[ "${line_count}" -eq 2 ]]
+}
+
+@test "closed: -n shorthand for --limit" {
+  local out1 out2 out3
+  out1="$(todo add "Ticket A")"
+  out2="$(todo add "Ticket B")"
+  out3="$(todo add "Ticket C")"
+  local id1 id2 id3
+  id1="$(extract_id_from_add "${out1}")"
+  id2="$(extract_id_from_add "${out2}")"
+  id3="$(extract_id_from_add "${out3}")"
+
+  todo close "${id1}"
+  todo close "${id2}"
+  todo close "${id3}"
+
+  run todo closed -n 1
+  assert_success
+  local line_count
+  line_count="$(echo "${output}" | wc -l | tr -d ' ')"
+  [[ "${line_count}" -eq 1 ]]
+}
+
+@test "closed: -a filters by assignee" {
+  local out1 out2
+  out1="$(todo add "Alice task" -a alice)"
+  out2="$(todo add "Bob task" -a bob)"
+  local id1 id2
+  id1="$(extract_id_from_add "${out1}")"
+  id2="$(extract_id_from_add "${out2}")"
+
+  todo close "${id1}"
+  todo close "${id2}"
+
+  run todo closed -a alice
+  assert_success
+  assert_output --partial "Alice task"
+  refute_output --partial "Bob task"
+}
+
+@test "closed: -T filters by tag" {
+  local out1 out2
+  out1="$(todo add "Backend task" --tags "backend,urgent")"
+  out2="$(todo add "Frontend task" --tags "frontend")"
+  local id1 id2
+  id1="$(extract_id_from_add "${out1}")"
+  id2="$(extract_id_from_add "${out2}")"
+
+  todo close "${id1}"
+  todo close "${id2}"
+
+  run todo closed -T backend
+  assert_success
+  assert_output --partial "Backend task"
+  refute_output --partial "Frontend task"
+}
+
+@test "closed: output format is id - Title without status" {
+  local out
+  out="$(todo add "Format test")"
+  local id
+  id="$(extract_id_from_add "${out}")"
+
+  todo close "${id}"
+
+  run todo closed
+  assert_success
+  assert_output --partial "- Format test"
+  # Status should NOT be shown since all displayed are closed
+  refute_output --partial "[closed]"
+}
+
+@test "closed: combined filters" {
+  local out1 out2 out3
+  out1="$(todo add "Alice backend" -a alice --tags "backend")"
+  out2="$(todo add "Alice frontend" -a alice --tags "frontend")"
+  out3="$(todo add "Bob backend" -a bob --tags "backend")"
+  local id1 id2 id3
+  id1="$(extract_id_from_add "${out1}")"
+  id2="$(extract_id_from_add "${out2}")"
+  id3="$(extract_id_from_add "${out3}")"
+
+  todo close "${id1}"
+  todo close "${id2}"
+  todo close "${id3}"
+
+  run todo closed -a alice -T backend
+  assert_success
+  assert_output --partial "Alice backend"
+  refute_output --partial "Alice frontend"
+  refute_output --partial "Bob backend"
+}


### PR DESCRIPTION
Adds `todo closed` command to display recently closed tickets sorted by file modification time (most recent first), with limit and filter support.

- Add `formatClosedLine()` to `cmd/format.go` — simple `id - Title` format (status omitted since all displayed tickets are closed)
- Create `cmd/closed.go` — Cobra command with `cobra.NoArgs`, filters `tickets.List()` to `Status == "closed"`, stats files via `os.Stat()` for mtime, sorts descending, truncates by limit
- Flags: `--limit`/`-n` (int, default 20), `-a/--assignee` (string), `-T/--tag` (string)
- Create `test/closed.bats` — 11 integration tests covering: empty list, shows closed only, hides open/in_progress, mtime sorting (via `touch -t`), `--limit`, `-n` shorthand, assignee filter, tag filter, output format, combined filters
- Update `README.md` — add "Closed tickets" section with usage examples and flags table
- Update `CHANGELOG.md` — add entry under `[Unreleased] > Added`

All 73 unit tests and 172 bats integration tests pass.
