### PR TITLE
Enhance show command with computed relationships and pager support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `todo ready` — show tickets ready to work on (open/in_progress with all deps closed or no deps), sorted by priority then ID, with `-a/--assignee` and `-T/--tag` filters
 - `todo blocked` — show tickets blocked by unclosed dependencies (open/in_progress with ≥1 unclosed dep), sorted by priority then ID, with `-a/--assignee` and `-T/--tag` filters
 - `todo closed` — show recently closed tickets sorted by file modification time (most recent first), with `--limit`/`-n` (default 20), `-a/--assignee`, and `-T/--tag` filters
+- `todo show` now displays computed relationship sections: Blockers (unclosed deps), Blocking (reverse deps), Children (sub-tickets), and Linked (resolved links). Sections only shown when non-empty.
+- `TODO_PAGER` environment variable: set to pipe `todo show` output through a pager (e.g. `less -R`). Only activates when stdout is a terminal.
 
 ### Changed
 
@@ -38,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - File format uses YAML frontmatter (`---` delimited) followed by `# Title` heading and description
   - Enables better git diffs and easier manual editing
 - `todo done` now sets `status: closed` instead of deleting the ticket file. Closed tickets are preserved on disk but hidden from `list` and TUI.
+- `todo show` enhances the `parent:` frontmatter line with the parent ticket's title (e.g. `parent: aBc (Fix login timeout)`)
 - `todo list` output format now shows `id [status] - Title <- [dep1, dep2]` (status and deps omitted when empty)
 - Empty `todo list` result now produces no output instead of "No tickets" message
 - All commands now reference tickets by ID only, not by title

--- a/README.md
+++ b/README.md
@@ -123,6 +123,28 @@ An empty result produces no output.
 todo show aBc
 ```
 
+The output includes YAML frontmatter, title, description, and computed relationship sections:
+
+- **Blockers** — unclosed tickets this ticket depends on
+- **Blocking** — tickets that depend on this ticket (when this ticket is unclosed)
+- **Children** — tickets whose parent is this ticket
+- **Linked** — tickets linked to this ticket
+
+Sections are only shown when non-empty. Each entry is formatted as `- id [status] Title`.
+
+When a ticket has a parent, the frontmatter `parent:` line is enhanced with the parent's title (e.g. `parent: aBc (Fix login timeout)`).
+
+#### Pager support
+
+Set the `TODO_PAGER` environment variable to pipe `show` output through a pager:
+
+```bash
+export TODO_PAGER="less -R"
+todo show aBc
+```
+
+The pager is only used when stdout is a terminal (piped output is never paged).
+
 ### Partial ID matching
 
 All commands that accept a ticket ID support partial matching. You can use any unique substring of the ID:

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -2,17 +2,21 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"os/exec"
+	"strings"
 
 	"github.com/juanibiapina/todo/internal/tickets"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var showCmd = &cobra.Command{
 	Use:   "show <id>",
 	Short: "Show a ticket's full details",
 	Long:  `Show the full details of a ticket, including its front matter and description.`,
-	Args: cobra.ExactArgs(1),
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ref := args[0]
 
@@ -26,10 +30,63 @@ var showCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Print(ticket.FullString())
+		// Load all tickets for computing relations
+		allTickets, err := tickets.List(dir)
+		if err != nil {
+			return err
+		}
 
+		rel := tickets.ComputeRelations(ticket, allTickets)
+
+		// Build output
+		var b strings.Builder
+
+		// If parent has a resolved title, enhance the frontmatter parent line
+		output := ticket.FullString()
+		if parentLine := tickets.FormatParentLine(rel); parentLine != "" {
+			output = strings.Replace(output, "parent: "+ticket.Parent, "parent: "+parentLine, 1)
+		}
+		b.WriteString(output)
+
+		// Append computed relation sections
+		b.WriteString(tickets.FormatRelations(rel))
+
+		result := b.String()
+
+		// Pipe through pager if TODO_PAGER is set and stdout is a TTY
+		pager := os.Getenv("TODO_PAGER")
+		if pager != "" && term.IsTerminal(int(os.Stdout.Fd())) {
+			return runPager(pager, result)
+		}
+
+		fmt.Print(result)
 		return nil
 	},
+}
+
+// runPager pipes content through the specified pager command.
+func runPager(pager string, content string) error {
+	pagerCmd := exec.Command("sh", "-c", pager)
+	pagerCmd.Stdout = os.Stdout
+	pagerCmd.Stderr = os.Stderr
+
+	stdin, err := pagerCmd.StdinPipe()
+	if err != nil {
+		// Fall back to direct output
+		fmt.Print(content)
+		return nil
+	}
+
+	if err := pagerCmd.Start(); err != nil {
+		// Fall back to direct output
+		fmt.Print(content)
+		return nil
+	}
+
+	io.WriteString(stdin, content)
+	stdin.Close()
+
+	return pagerCmd.Wait()
 }
 
 func init() {

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/term v0.31.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -44,6 +45,5 @@ require (
 	github.com/yuin/goldmark-emoji v1.0.5 // indirect
 	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
-	golang.org/x/term v0.31.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
 )

--- a/internal/tickets/relations.go
+++ b/internal/tickets/relations.go
@@ -1,0 +1,142 @@
+package tickets
+
+import (
+	"fmt"
+	"strings"
+)
+
+// TicketRelations holds computed relationships for a ticket.
+type TicketRelations struct {
+	// ParentTicket is the resolved parent ticket (nil if no parent or not found).
+	ParentTicket *Ticket
+	// Blockers are unclosed tickets this ticket depends on.
+	Blockers []*Ticket
+	// Blocking are tickets that depend on this ticket (and this ticket is unclosed).
+	Blocking []*Ticket
+	// Children are tickets whose parent is this ticket.
+	Children []*Ticket
+	// Linked are resolved tickets from this ticket's links.
+	Linked []*Ticket
+}
+
+// ComputeRelations computes all relationships for a given ticket
+// using the full list of all tickets.
+func ComputeRelations(ticket *Ticket, allTickets []*Ticket) *TicketRelations {
+	// Build ID -> Ticket map
+	ticketMap := make(map[string]*Ticket)
+	for _, t := range allTickets {
+		ticketMap[t.ID] = t
+	}
+
+	rel := &TicketRelations{}
+
+	// Resolve parent with title
+	if ticket.Parent != "" {
+		if parent, ok := ticketMap[ticket.Parent]; ok {
+			rel.ParentTicket = parent
+		}
+	}
+
+	// Blockers: unclosed deps of this ticket
+	for _, depID := range ticket.Deps {
+		if dep, ok := ticketMap[depID]; ok {
+			if dep.Status != "closed" {
+				rel.Blockers = append(rel.Blockers, dep)
+			}
+		}
+	}
+
+	// Blocking: tickets that have this ticket as a dep, where this ticket is unclosed
+	if ticket.Status != "closed" {
+		for _, t := range allTickets {
+			if t.ID == ticket.ID {
+				continue
+			}
+			for _, depID := range t.Deps {
+				if depID == ticket.ID {
+					rel.Blocking = append(rel.Blocking, t)
+					break
+				}
+			}
+		}
+	}
+
+	// Children: tickets whose parent is this ticket
+	for _, t := range allTickets {
+		if t.Parent == ticket.ID {
+			rel.Children = append(rel.Children, t)
+		}
+	}
+
+	// Linked: resolve link IDs to tickets
+	for _, linkID := range ticket.Links {
+		if linked, ok := ticketMap[linkID]; ok {
+			rel.Linked = append(rel.Linked, linked)
+		}
+	}
+
+	return rel
+}
+
+// FormatRelations returns a formatted string of relationship sections.
+// Only non-empty sections are included. Returns empty string if no relations.
+func FormatRelations(rel *TicketRelations) string {
+	var b strings.Builder
+
+	if rel.ParentTicket != nil {
+		// This is handled by enhancing the parent line in FullString output,
+		// so we don't add a separate section here.
+	}
+
+	if len(rel.Blockers) > 0 {
+		b.WriteString("\n## Blockers\n")
+		for _, t := range rel.Blockers {
+			b.WriteString(formatRelationLine(t))
+			b.WriteString("\n")
+		}
+	}
+
+	if len(rel.Blocking) > 0 {
+		b.WriteString("\n## Blocking\n")
+		for _, t := range rel.Blocking {
+			b.WriteString(formatRelationLine(t))
+			b.WriteString("\n")
+		}
+	}
+
+	if len(rel.Children) > 0 {
+		b.WriteString("\n## Children\n")
+		for _, t := range rel.Children {
+			b.WriteString(formatRelationLine(t))
+			b.WriteString("\n")
+		}
+	}
+
+	if len(rel.Linked) > 0 {
+		b.WriteString("\n## Linked\n")
+		for _, t := range rel.Linked {
+			b.WriteString(formatRelationLine(t))
+			b.WriteString("\n")
+		}
+	}
+
+	return b.String()
+}
+
+// formatRelationLine formats a single ticket reference for a relation section.
+// Format: "- id [status] Title" or "- id Title" when status is empty.
+func formatRelationLine(t *Ticket) string {
+	if t.Status != "" {
+		return fmt.Sprintf("- %s [%s] %s", t.ID, t.Status, t.Title)
+	}
+	return fmt.Sprintf("- %s %s", t.ID, t.Title)
+}
+
+// FormatParentLine returns an enhanced parent line with title.
+// Format: "parent: id (Title)" or empty string if no parent ticket.
+func FormatParentLine(rel *TicketRelations) string {
+	if rel.ParentTicket == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s (%s)", rel.ParentTicket.ID, rel.ParentTicket.Title)
+}

--- a/internal/tickets/relations_test.go
+++ b/internal/tickets/relations_test.go
@@ -1,0 +1,264 @@
+package tickets
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestComputeRelations_NoRelations(t *testing.T) {
+	ticket := &Ticket{ID: "aaa", Title: "Standalone"}
+	all := []*Ticket{ticket}
+
+	rel := ComputeRelations(ticket, all)
+
+	if rel.ParentTicket != nil {
+		t.Errorf("expected nil parent, got %v", rel.ParentTicket)
+	}
+	if len(rel.Blockers) != 0 {
+		t.Errorf("expected 0 blockers, got %d", len(rel.Blockers))
+	}
+	if len(rel.Blocking) != 0 {
+		t.Errorf("expected 0 blocking, got %d", len(rel.Blocking))
+	}
+	if len(rel.Children) != 0 {
+		t.Errorf("expected 0 children, got %d", len(rel.Children))
+	}
+	if len(rel.Linked) != 0 {
+		t.Errorf("expected 0 linked, got %d", len(rel.Linked))
+	}
+}
+
+func TestComputeRelations_Parent(t *testing.T) {
+	parent := &Ticket{ID: "par", Title: "Parent Ticket"}
+	child := &Ticket{ID: "chi", Title: "Child Ticket", Parent: "par"}
+	all := []*Ticket{parent, child}
+
+	rel := ComputeRelations(child, all)
+
+	if rel.ParentTicket == nil {
+		t.Fatal("expected parent ticket, got nil")
+	}
+	if rel.ParentTicket.ID != "par" {
+		t.Errorf("expected parent ID 'par', got %q", rel.ParentTicket.ID)
+	}
+	if rel.ParentTicket.Title != "Parent Ticket" {
+		t.Errorf("expected parent title 'Parent Ticket', got %q", rel.ParentTicket.Title)
+	}
+}
+
+func TestComputeRelations_ParentNotFound(t *testing.T) {
+	ticket := &Ticket{ID: "aaa", Title: "Orphan", Parent: "zzz"}
+	all := []*Ticket{ticket}
+
+	rel := ComputeRelations(ticket, all)
+
+	if rel.ParentTicket != nil {
+		t.Errorf("expected nil parent for missing parent ID, got %v", rel.ParentTicket)
+	}
+}
+
+func TestComputeRelations_Blockers(t *testing.T) {
+	dep1 := &Ticket{ID: "d1a", Title: "Open Dep", Status: "open"}
+	dep2 := &Ticket{ID: "d2a", Title: "Closed Dep", Status: "closed"}
+	dep3 := &Ticket{ID: "d3a", Title: "In Progress Dep", Status: "in_progress"}
+	ticket := &Ticket{ID: "aaa", Title: "Main", Deps: []string{"d1a", "d2a", "d3a"}}
+	all := []*Ticket{dep1, dep2, dep3, ticket}
+
+	rel := ComputeRelations(ticket, all)
+
+	if len(rel.Blockers) != 2 {
+		t.Fatalf("expected 2 blockers (open + in_progress), got %d", len(rel.Blockers))
+	}
+	if rel.Blockers[0].ID != "d1a" {
+		t.Errorf("expected first blocker 'd1a', got %q", rel.Blockers[0].ID)
+	}
+	if rel.Blockers[1].ID != "d3a" {
+		t.Errorf("expected second blocker 'd3a', got %q", rel.Blockers[1].ID)
+	}
+}
+
+func TestComputeRelations_BlockersMissingDep(t *testing.T) {
+	ticket := &Ticket{ID: "aaa", Title: "Main", Deps: []string{"zzz"}}
+	all := []*Ticket{ticket}
+
+	rel := ComputeRelations(ticket, all)
+
+	// Missing deps are not listed as blockers
+	if len(rel.Blockers) != 0 {
+		t.Errorf("expected 0 blockers for missing dep, got %d", len(rel.Blockers))
+	}
+}
+
+func TestComputeRelations_Blocking(t *testing.T) {
+	ticket := &Ticket{ID: "aaa", Title: "Blocker", Status: "open"}
+	blocked1 := &Ticket{ID: "b1a", Title: "Blocked 1", Deps: []string{"aaa"}}
+	blocked2 := &Ticket{ID: "b2a", Title: "Blocked 2", Deps: []string{"aaa"}}
+	unrelated := &Ticket{ID: "uuu", Title: "Unrelated"}
+	all := []*Ticket{ticket, blocked1, blocked2, unrelated}
+
+	rel := ComputeRelations(ticket, all)
+
+	if len(rel.Blocking) != 2 {
+		t.Fatalf("expected 2 blocking, got %d", len(rel.Blocking))
+	}
+}
+
+func TestComputeRelations_BlockingNotShownWhenClosed(t *testing.T) {
+	ticket := &Ticket{ID: "aaa", Title: "Done", Status: "closed"}
+	blocked := &Ticket{ID: "bbb", Title: "Depends on Done", Deps: []string{"aaa"}}
+	all := []*Ticket{ticket, blocked}
+
+	rel := ComputeRelations(ticket, all)
+
+	// When the ticket is closed, it doesn't block anyone
+	if len(rel.Blocking) != 0 {
+		t.Errorf("expected 0 blocking when ticket is closed, got %d", len(rel.Blocking))
+	}
+}
+
+func TestComputeRelations_Children(t *testing.T) {
+	parent := &Ticket{ID: "par", Title: "Epic"}
+	child1 := &Ticket{ID: "c1a", Title: "Task 1", Parent: "par"}
+	child2 := &Ticket{ID: "c2a", Title: "Task 2", Parent: "par"}
+	other := &Ticket{ID: "ooo", Title: "Other", Parent: "xxx"}
+	all := []*Ticket{parent, child1, child2, other}
+
+	rel := ComputeRelations(parent, all)
+
+	if len(rel.Children) != 2 {
+		t.Fatalf("expected 2 children, got %d", len(rel.Children))
+	}
+	if rel.Children[0].ID != "c1a" {
+		t.Errorf("expected first child 'c1a', got %q", rel.Children[0].ID)
+	}
+	if rel.Children[1].ID != "c2a" {
+		t.Errorf("expected second child 'c2a', got %q", rel.Children[1].ID)
+	}
+}
+
+func TestComputeRelations_Linked(t *testing.T) {
+	ticket := &Ticket{ID: "aaa", Title: "Main", Links: []string{"bbb", "ccc"}}
+	link1 := &Ticket{ID: "bbb", Title: "Linked 1"}
+	link2 := &Ticket{ID: "ccc", Title: "Linked 2"}
+	all := []*Ticket{ticket, link1, link2}
+
+	rel := ComputeRelations(ticket, all)
+
+	if len(rel.Linked) != 2 {
+		t.Fatalf("expected 2 linked, got %d", len(rel.Linked))
+	}
+	if rel.Linked[0].ID != "bbb" {
+		t.Errorf("expected first linked 'bbb', got %q", rel.Linked[0].ID)
+	}
+}
+
+func TestComputeRelations_LinkedMissing(t *testing.T) {
+	ticket := &Ticket{ID: "aaa", Title: "Main", Links: []string{"zzz"}}
+	all := []*Ticket{ticket}
+
+	rel := ComputeRelations(ticket, all)
+
+	// Missing links are not listed
+	if len(rel.Linked) != 0 {
+		t.Errorf("expected 0 linked for missing link, got %d", len(rel.Linked))
+	}
+}
+
+func TestFormatRelations_Empty(t *testing.T) {
+	rel := &TicketRelations{}
+
+	result := FormatRelations(rel)
+
+	if result != "" {
+		t.Errorf("expected empty string for no relations, got %q", result)
+	}
+}
+
+func TestFormatRelations_AllSections(t *testing.T) {
+	rel := &TicketRelations{
+		Blockers: []*Ticket{
+			{ID: "b1a", Title: "Blocker One", Status: "open"},
+		},
+		Blocking: []*Ticket{
+			{ID: "b2a", Title: "Blocked By Me", Status: "in_progress"},
+		},
+		Children: []*Ticket{
+			{ID: "c1a", Title: "Child Task"},
+		},
+		Linked: []*Ticket{
+			{ID: "l1a", Title: "Related", Status: "open"},
+		},
+	}
+
+	result := FormatRelations(rel)
+
+	if !strings.Contains(result, "## Blockers") {
+		t.Error("expected Blockers section")
+	}
+	if !strings.Contains(result, "- b1a [open] Blocker One") {
+		t.Error("expected blocker line with status")
+	}
+	if !strings.Contains(result, "## Blocking") {
+		t.Error("expected Blocking section")
+	}
+	if !strings.Contains(result, "- b2a [in_progress] Blocked By Me") {
+		t.Error("expected blocking line with status")
+	}
+	if !strings.Contains(result, "## Children") {
+		t.Error("expected Children section")
+	}
+	if !strings.Contains(result, "- c1a Child Task") {
+		t.Error("expected child line without status (empty)")
+	}
+	if !strings.Contains(result, "## Linked") {
+		t.Error("expected Linked section")
+	}
+	if !strings.Contains(result, "- l1a [open] Related") {
+		t.Error("expected linked line with status")
+	}
+}
+
+func TestFormatRelations_OnlyBlockers(t *testing.T) {
+	rel := &TicketRelations{
+		Blockers: []*Ticket{
+			{ID: "aaa", Title: "Dep", Status: "open"},
+		},
+	}
+
+	result := FormatRelations(rel)
+
+	if !strings.Contains(result, "## Blockers") {
+		t.Error("expected Blockers section")
+	}
+	if strings.Contains(result, "## Blocking") {
+		t.Error("unexpected Blocking section")
+	}
+	if strings.Contains(result, "## Children") {
+		t.Error("unexpected Children section")
+	}
+	if strings.Contains(result, "## Linked") {
+		t.Error("unexpected Linked section")
+	}
+}
+
+func TestFormatParentLine(t *testing.T) {
+	rel := &TicketRelations{
+		ParentTicket: &Ticket{ID: "par", Title: "Epic"},
+	}
+
+	result := FormatParentLine(rel)
+
+	if result != "par (Epic)" {
+		t.Errorf("expected 'par (Epic)', got %q", result)
+	}
+}
+
+func TestFormatParentLine_NoParent(t *testing.T) {
+	rel := &TicketRelations{}
+
+	result := FormatParentLine(rel)
+
+	if result != "" {
+		t.Errorf("expected empty string, got %q", result)
+	}
+}

--- a/test/dep.bats
+++ b/test/dep.bats
@@ -36,13 +36,13 @@ load test_helper
   run todo dep "${id_a}" "${id_b}"
   assert_success
 
-  # Should only have one dep entry, not two
+  # Should only have one dep entry, not two — count in the YAML frontmatter section only
   run todo show "${id_a}"
   assert_success
-  # Count occurrences of the dep ID in deps section
-  local count
-  count=$(echo "$output" | grep -c "${id_b}" || true)
-  [ "$count" -eq 1 ]
+  # Extract frontmatter (between --- delimiters) and count dep ID occurrences
+  local fm_count
+  fm_count=$(echo "$output" | sed -n '/^---$/,/^---$/p' | grep -c "${id_b}" || true)
+  [ "$fm_count" -eq 1 ]
 }
 
 @test "dep fails when ticket does not exist" {

--- a/test/link.bats
+++ b/test/link.bats
@@ -79,12 +79,13 @@ load test_helper
   run todo link "${id_a}" "${id_b}"
   assert_success
 
-  # A should have B only once
+  # A should have B only once — count in the YAML frontmatter section only
   run todo show "${id_a}"
   assert_success
-  local count
-  count=$(echo "$output" | grep -c "${id_b}" || true)
-  [ "$count" -eq 1 ]
+  # Extract frontmatter (between --- delimiters) and count link ID occurrences
+  local fm_count
+  fm_count=$(echo "$output" | sed -n '/^---$/,/^---$/p' | grep -c "${id_b}" || true)
+  [ "$fm_count" -eq 1 ]
 }
 
 @test "link fails when ticket does not exist" {

--- a/test/show.bats
+++ b/test/show.bats
@@ -43,3 +43,170 @@ load test_helper
   assert_output --partial "# Markdown ticket"
   assert_output --partial "---"
 }
+
+@test "show: displays Blockers section for unclosed deps" {
+  local out1 out2
+  out1="$(todo add "Blocker task")"
+  local dep_id
+  dep_id="$(echo "${out1}" | awk '{print $2}')"
+
+  out2="$(todo add "Blocked task")"
+  local id
+  id="$(echo "${out2}" | awk '{print $2}')"
+
+  todo dep "${id}" "${dep_id}"
+
+  run todo show "${id}"
+  assert_success
+  assert_output --partial "## Blockers"
+  assert_output --partial "${dep_id}"
+  assert_output --partial "Blocker task"
+}
+
+@test "show: no Blockers section when deps are closed" {
+  local out1 out2
+  out1="$(todo add "Closed dep")"
+  local dep_id
+  dep_id="$(echo "${out1}" | awk '{print $2}')"
+
+  out2="$(todo add "Main task")"
+  local id
+  id="$(echo "${out2}" | awk '{print $2}')"
+
+  todo dep "${id}" "${dep_id}"
+  todo done "${dep_id}"
+
+  run todo show "${id}"
+  assert_success
+  refute_output --partial "## Blockers"
+}
+
+@test "show: displays Blocking section for reverse deps" {
+  local out1 out2
+  out1="$(todo add "Upstream task")"
+  local id
+  id="$(echo "${out1}" | awk '{print $2}')"
+
+  out2="$(todo add "Downstream task")"
+  local blocked_id
+  blocked_id="$(echo "${out2}" | awk '{print $2}')"
+
+  todo dep "${blocked_id}" "${id}"
+
+  run todo show "${id}"
+  assert_success
+  assert_output --partial "## Blocking"
+  assert_output --partial "${blocked_id}"
+  assert_output --partial "Downstream task"
+}
+
+@test "show: no Blocking section when ticket is closed" {
+  local out1 out2
+  out1="$(todo add "Done task")"
+  local id
+  id="$(echo "${out1}" | awk '{print $2}')"
+
+  out2="$(todo add "Depends on done")"
+  local blocked_id
+  blocked_id="$(echo "${out2}" | awk '{print $2}')"
+
+  todo dep "${blocked_id}" "${id}"
+  todo done "${id}"
+
+  run todo show "${id}"
+  assert_success
+  refute_output --partial "## Blocking"
+}
+
+@test "show: displays Children section" {
+  local out1
+  out1="$(todo add "Parent epic")"
+  local parent_id
+  parent_id="$(echo "${out1}" | awk '{print $2}')"
+
+  local out2
+  out2="$(todo add "Child task" --parent "${parent_id}")"
+  local child_id
+  child_id="$(echo "${out2}" | awk '{print $2}')"
+
+  run todo show "${parent_id}"
+  assert_success
+  assert_output --partial "## Children"
+  assert_output --partial "${child_id}"
+  assert_output --partial "Child task"
+}
+
+@test "show: displays Linked section" {
+  local out1 out2
+  out1="$(todo add "First ticket")"
+  local id1
+  id1="$(echo "${out1}" | awk '{print $2}')"
+
+  out2="$(todo add "Second ticket")"
+  local id2
+  id2="$(echo "${out2}" | awk '{print $2}')"
+
+  todo link "${id1}" "${id2}"
+
+  run todo show "${id1}"
+  assert_success
+  assert_output --partial "## Linked"
+  assert_output --partial "${id2}"
+  assert_output --partial "Second ticket"
+}
+
+@test "show: enhances parent line with title" {
+  local out1
+  out1="$(todo add "Parent ticket")"
+  local parent_id
+  parent_id="$(echo "${out1}" | awk '{print $2}')"
+
+  local out2
+  out2="$(todo add "Child ticket" --parent "${parent_id}")"
+  local child_id
+  child_id="$(echo "${out2}" | awk '{print $2}')"
+
+  run todo show "${child_id}"
+  assert_success
+  assert_output --partial "parent: ${parent_id} (Parent ticket)"
+}
+
+@test "show: no relation sections when ticket has none" {
+  local out
+  out="$(todo add "Lonely ticket")"
+  local id
+  id="$(echo "${out}" | awk '{print $2}')"
+
+  run todo show "${id}"
+  assert_success
+  refute_output --partial "## Blockers"
+  refute_output --partial "## Blocking"
+  refute_output --partial "## Children"
+  refute_output --partial "## Linked"
+}
+
+@test "show: TODO_PAGER pipes through pager" {
+  local out
+  out="$(todo add "Pager test")"
+  local id
+  id="$(echo "${out}" | awk '{print $2}')"
+
+  # Use cat as the pager — output should be identical
+  run env TODO_PAGER=cat todo show "${id}"
+  assert_success
+  assert_output --partial "Pager test"
+  assert_output --partial "id: ${id}"
+}
+
+@test "show: no pager when stdout is not a TTY" {
+  local out
+  out="$(todo add "Pipe test")"
+  local id
+  id="$(echo "${out}" | awk '{print $2}')"
+
+  # Piping to cat means stdout is not a TTY — pager should not be used
+  local result
+  result="$(TODO_PAGER=cat todo show "${id}" | cat)"
+  [[ "${result}" == *"Pipe test"* ]]
+  [[ "${result}" == *"id: ${id}"* ]]
+}


### PR DESCRIPTION
Enhances `todo show` with computed ticket relationships and pager support via `TODO_PAGER` env var.

- **`internal/tickets/relations.go`**: New `TicketRelations` struct with `ComputeRelations()` and `FormatRelations()` — computes Blockers (unclosed deps), Blocking (reverse deps where ticket is unclosed), Children (tickets with matching parent), and Linked (resolved links). Sections only shown when non-empty.
- **`internal/tickets/relations_test.go`**: 15 unit tests covering all relation computation and formatting.
- **`cmd/show.go`**: Rewritten to load all tickets via `tickets.List()`, compute relations, enhance parent line with title (e.g. `parent: aBc (Fix login timeout)`), append formatted relation sections, and pipe through `TODO_PAGER` when stdout is TTY (via `golang.org/x/term`).
- **`go.mod`**: Promoted `golang.org/x/term` from indirect to direct dependency.
- **`test/show.bats`**: 10 new integration tests (Blockers, no Blockers when deps closed, Blocking, no Blocking when closed, Children, Linked, parent with title, no relation sections, TODO_PAGER, no pager without TTY).
- **`test/dep.bats`** and **`test/link.bats`**: Fixed idempotent tests — count dep/link IDs only in YAML frontmatter (since show output now includes relation sections mentioning same IDs).
- **`README.md`**: Added relationship sections and pager support documentation.
- **`CHANGELOG.md`**: Added entries for relationship sections, pager support, and enhanced parent line.

All 88 unit tests and 182 bats integration tests pass.
