### PR TITLE
Add add-note command for appending timestamped notes to tickets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `todo closed` — show recently closed tickets sorted by file modification time (most recent first), with `--limit`/`-n` (default 20), `-a/--assignee`, and `-T/--tag` filters
 - `todo show` now displays computed relationship sections: Blockers (unclosed deps), Blocking (reverse deps), Children (sub-tickets), and Linked (resolved links). Sections only shown when non-empty.
 - `TODO_PAGER` environment variable: set to pipe `todo show` output through a pager (e.g. `less -R`). Only activates when stdout is a terminal.
+- `todo add-note <id> [text]` — append a timestamped note under a `## Notes` section in the ticket description. Supports positional argument or stdin for multi-line content.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -337,6 +337,36 @@ todo closed -T backend
 | `--assignee` | `-a` | | Filter by assignee |
 | `--tag` | `-T` | | Filter by tag |
 
+### Add notes
+
+```bash
+# Add a note with positional argument
+todo add-note aBc 'Discussed with team, agreed on approach'
+
+# Add a note via stdin (for multi-line content)
+todo add-note aBc <<'EOF'
+Spoke with PM about requirements:
+- Need to support OAuth2
+- Deadline is next Friday
+EOF
+```
+
+Notes are appended to the ticket's description under a `## Notes` section. Each note is prefixed with a UTC timestamp in bold:
+
+```markdown
+## Notes
+
+**2026-02-18 10:30 UTC**
+
+Discussed with team, agreed on approach
+
+**2026-02-18 14:15 UTC**
+
+Follow-up: implementation started
+```
+
+The `## Notes` header is created automatically on the first note and reused for subsequent notes. Partial ID matching is supported.
+
 ### Manage links
 
 ```bash

--- a/cmd/add_note.go
+++ b/cmd/add_note.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/juanibiapina/todo/internal/tickets"
+	"github.com/spf13/cobra"
+)
+
+var addNoteCmd = &cobra.Command{
+	Use:   "add-note <id> [text]",
+	Short: "Append a timestamped note to a ticket",
+	Long: `Append a timestamped note to a ticket's description under a ## Notes section.
+
+Note text can be provided as:
+  1. A positional argument (for simple text)
+  2. Via stdin (for multi-line content)
+
+Each note is prefixed with a UTC timestamp. The ## Notes header is added
+automatically on the first note and reused for subsequent notes.`,
+	Args: cobra.RangeArgs(1, 2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ref := args[0]
+		var text string
+
+		if len(args) > 1 {
+			text = args[1]
+		} else {
+			// Check if stdin has data (not a terminal)
+			stat, _ := os.Stdin.Stat()
+			if (stat.Mode() & os.ModeCharDevice) == 0 {
+				data, err := io.ReadAll(os.Stdin)
+				if err != nil {
+					return fmt.Errorf("reading stdin: %w", err)
+				}
+				text = strings.TrimRight(string(data), "\n")
+			}
+		}
+
+		if text == "" {
+			return fmt.Errorf("no note text provided (pass as argument or via stdin)")
+		}
+
+		dir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		title, err := tickets.AddNote(dir, ref, text)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Added note to: %s\n", title)
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(addNoteCmd)
+}

--- a/test/add_note.bats
+++ b/test/add_note.bats
@@ -1,0 +1,122 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "add-note: adds a note to a ticket" {
+  local out
+  out="$(todo add "Note target")"
+  local id
+  id="$(extract_id_from_add "${out}")"
+
+  run todo add-note "${id}" "This is a note"
+  assert_success
+  assert_output --partial "Added note to"
+
+  run todo show "${id}"
+  assert_output --partial "## Notes"
+  assert_output --partial "This is a note"
+}
+
+@test "add-note: adds note via positional argument" {
+  local out
+  out="$(todo add "Positional note")"
+  local id
+  id="$(extract_id_from_add "${out}")"
+
+  run todo add-note "${id}" "Positional text"
+  assert_success
+
+  run todo show "${id}"
+  assert_output --partial "Positional text"
+}
+
+@test "add-note: adds note via stdin" {
+  local out
+  out="$(todo add "Stdin note")"
+  local id
+  id="$(extract_id_from_add "${out}")"
+
+  run bash -c "echo 'From stdin pipe' | todo add-note ${id}"
+  assert_success
+
+  run todo show "${id}"
+  assert_output --partial "From stdin pipe"
+}
+
+@test "add-note: appends to existing description" {
+  local out
+  out="$(todo add "With desc" "Original description")"
+  local id
+  id="$(extract_id_from_add "${out}")"
+
+  todo add-note "${id}" "Appended note"
+
+  run todo show "${id}"
+  assert_output --partial "Original description"
+  assert_output --partial "## Notes"
+  assert_output --partial "Appended note"
+}
+
+@test "add-note: does not duplicate Notes header" {
+  local out
+  out="$(todo add "Multi note")"
+  local id
+  id="$(extract_id_from_add "${out}")"
+
+  todo add-note "${id}" "First note"
+  todo add-note "${id}" "Second note"
+
+  run todo show "${id}"
+  assert_output --partial "First note"
+  assert_output --partial "Second note"
+
+  # Count ## Notes headers — should be exactly 1
+  local count
+  count="$(todo show "${id}" | grep -c '## Notes')"
+  [ "${count}" -eq 1 ]
+}
+
+@test "add-note: includes timestamp" {
+  local out
+  out="$(todo add "Timestamp note")"
+  local id
+  id="$(extract_id_from_add "${out}")"
+
+  todo add-note "${id}" "Timestamped text"
+
+  run todo show "${id}"
+  # Timestamp format: **YYYY-MM-DD HH:MM UTC**
+  assert_output --partial "**20"
+  assert_output --partial "UTC**"
+}
+
+@test "add-note: fails for nonexistent ticket" {
+  run todo add-note "ZZZ" "Some note"
+  assert_failure
+  assert_output --partial "ticket not found"
+}
+
+@test "add-note: fails with no text" {
+  local out
+  out="$(todo add "No text note")"
+  local id
+  id="$(extract_id_from_add "${out}")"
+
+  run todo add-note "${id}"
+  assert_failure
+  assert_output --partial "no note text provided"
+}
+
+@test "add-note: works with partial IDs" {
+  local out
+  out="$(todo add "Partial note")"
+  local id
+  id="$(extract_id_from_add "${out}")"
+  local partial="${id:0:2}"
+
+  run todo add-note "${partial}" "Partial ID note"
+  assert_success
+
+  run todo show "${id}"
+  assert_output --partial "Partial ID note"
+}


### PR DESCRIPTION
Adds `todo add-note <id> [text]` command for appending timestamped notes to ticket files under a `## Notes` section.

- `internal/tickets/file.go` — Added `AddNote(dir, id, text string) (string, error)` function that finds the ticket via `findTicketFile`, appends `**<timestamp>**\n\n<text>` under a `## Notes` header (created if missing, reused if exists)
- `cmd/add_note.go` — New cobra command `add-note` with `RangeArgs(1, 2)`, reads note text from positional argument or stdin, errors on empty text
- `internal/tickets/file_test.go` — 5 new unit tests: `TestAddNote`, `TestAddNoteToExistingDescription`, `TestAddNoteMultiple`, `TestAddNoteEmptyDescription`, `TestAddNoteNotFound`
- `test/add_note.bats` — 9 new integration tests: basic add, positional arg, stdin pipe, append to existing description, no duplicate `## Notes` header, timestamp verification, nonexistent ticket error, no text error, partial ID matching
- `README.md` — Added "Add notes" section with usage examples (positional arg and stdin)
- `CHANGELOG.md` — Added entry for `todo add-note` command

All 93 unit tests and 191 bats integration tests pass.