### PR TITLE
Add edit command to open ticket in $EDITOR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `todo show` now displays computed relationship sections: Blockers (unclosed deps), Blocking (reverse deps), Children (sub-tickets), and Linked (resolved links). Sections only shown when non-empty.
 - `TODO_PAGER` environment variable: set to pipe `todo show` output through a pager (e.g. `less -R`). Only activates when stdout is a terminal.
 - `todo add-note <id> [text]` — append a timestamped note under a `## Notes` section in the ticket description. Supports positional argument or stdin for multi-line content.
+- `todo edit <id>` — open a ticket file in `$EDITOR` (default `vi`). Prints the file path instead when stdout is not a terminal.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,22 @@ The `validateToken` function doesn't handle expired tokens.
 EOF
 ```
 
+### Edit a ticket
+
+```bash
+todo edit aBc
+```
+
+Opens the ticket file in your `$EDITOR` (defaults to `vi` if not set). Supports partial ID matching.
+
+When stdout is not a terminal (e.g. in a script or pipe), the file path is printed instead of launching an editor:
+
+```bash
+# Get the file path for scripting
+path=$(todo edit aBc)
+echo "$path"  # docs/tickets/aBc.md
+```
+
 ### Complete a ticket
 
 ```bash

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/juanibiapina/todo/internal/tickets"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+var editCmd = &cobra.Command{
+	Use:   "edit <id>",
+	Short: "Open a ticket in your editor",
+	Long:  `Open a ticket file in $EDITOR (default vi). If stdout is not a TTY, prints the file path instead.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ref := args[0]
+
+		dir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		// Resolve the ticket (validates existence and handles partial IDs)
+		ticket, err := tickets.Show(dir, ref)
+		if err != nil {
+			return err
+		}
+
+		ticketPath := filepath.Join(tickets.DirPath(dir), ticket.ID+".md")
+
+		// If stdout is not a TTY, print the file path
+		if !term.IsTerminal(int(os.Stdout.Fd())) {
+			fmt.Println(ticketPath)
+			return nil
+		}
+
+		// Launch editor
+		editor := os.Getenv("EDITOR")
+		if editor == "" {
+			editor = "vi"
+		}
+
+		editorCmd := exec.Command(editor, ticketPath)
+		editorCmd.Stdin = os.Stdin
+		editorCmd.Stdout = os.Stdout
+		editorCmd.Stderr = os.Stderr
+
+		return editorCmd.Run()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(editCmd)
+}

--- a/test/edit.bats
+++ b/test/edit.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "edit: prints file path when stdout is not a TTY" {
+  local out
+  out="$(todo add "Edit me")"
+  local id
+  id="$(echo "${out}" | awk '{print $2}')"
+
+  # Piping through cat makes stdout non-TTY
+  local result
+  result="$(todo edit "${id}" | cat)"
+  [[ "${result}" == *"docs/tickets/${id}.md"* ]]
+}
+
+@test "edit: resolves partial ID" {
+  local out
+  out="$(todo add "Partial edit")"
+  local id
+  id="$(echo "${out}" | awk '{print $2}')"
+
+  local partial="${id:0:2}"
+
+  local result
+  result="$(todo edit "${partial}" | cat)"
+  [[ "${result}" == *"docs/tickets/${id}.md"* ]]
+}
+
+@test "edit: nonexistent ID returns error" {
+  run todo edit "ZZZ"
+  assert_failure
+  assert_output --partial "ticket not found"
+}
+
+@test "edit: uses EDITOR env var in TTY mode" {
+  local out
+  out="$(todo add "Editor test")"
+  local id
+  id="$(echo "${out}" | awk '{print $2}')"
+
+  # Create a custom editor script that writes a marker file
+  local editor_script="${BATS_TEST_TMPDIR}/test_editor.sh"
+  cat > "${editor_script}" <<'SCRIPT'
+#!/bin/bash
+touch "${1}.edited"
+SCRIPT
+  chmod +x "${editor_script}"
+
+  # Use script to simulate a TTY so the editor path is taken
+  EDITOR="${editor_script}" script -q /dev/null todo edit "${id}" >/dev/null 2>&1 || true
+
+  # Verify the marker file was created next to the ticket file
+  local path
+  path="$(todo edit "${id}" | cat)"
+  [[ -f "${path}.edited" ]]
+}
+
+@test "edit: file path points to correct ticket file" {
+  local out
+  out="$(todo add "Path check")"
+  local id
+  id="$(echo "${out}" | awk '{print $2}')"
+
+  local result
+  result="$(todo edit "${id}" | cat)"
+
+  # The path should end with <id>.md
+  [[ "${result}" == *"/${id}.md" ]]
+}
+
+@test "edit: file is editable via the printed path" {
+  local out
+  out="$(todo add "Modify me")"
+  local id
+  id="$(echo "${out}" | awk '{print $2}')"
+
+  # Get file path via non-TTY mode
+  local path
+  path="$(todo edit "${id}" | cat)"
+
+  # Modify the file directly (simulating what an editor would do)
+  sed -i '' 's/Modify/Modified/' "${path}"
+
+  run todo show "${id}"
+  assert_success
+  assert_output --partial "Modified me"
+}
+
+@test "edit: requires exactly one argument" {
+  run todo edit
+  assert_failure
+
+  run todo edit "abc" "def"
+  assert_failure
+}


### PR DESCRIPTION
Adds `todo edit <id>` command that opens a ticket file in the user's editor for direct editing.

- **`cmd/edit.go`**: New Cobra command with `ExactArgs(1)`, resolves ticket via `tickets.Show()` (supports partial IDs), detects TTY via `golang.org/x/term.IsTerminal` — launches `$EDITOR` (default `vi`) when TTY, prints file path when non-TTY for scripting use
- **`test/edit.bats`**: 7 integration tests covering non-TTY path printing, partial ID resolution, nonexistent ID error, `$EDITOR` env var with TTY simulation via `script`, file path correctness, file editability, and argument validation
- **`README.md`**: Added "Edit a ticket" section with TTY and non-TTY usage examples
- **`CHANGELOG.md`**: Added entry under `[Unreleased] > Added`

All 93 unit tests and 198 bats integration tests pass.
