### PR TITLE
Add query command for JSONL ticket output with filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `TODO_PAGER` environment variable: set to pipe `todo show` output through a pager (e.g. `less -R`). Only activates when stdout is a terminal.
 - `todo add-note <id> [text]` — append a timestamped note under a `## Notes` section in the ticket description. Supports positional argument or stdin for multi-line content.
 - `todo edit <id>` — open a ticket file in `$EDITOR` (default `vi`). Prints the file path instead when stdout is not a terminal.
+- `todo query` — output all tickets as JSONL (one JSON object per line) with all frontmatter fields. Supports `--status`, `--type`, `-a/--assignee`, `-T/--tag` filters with AND logic.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -353,6 +353,57 @@ todo closed -T backend
 | `--assignee` | `-a` | | Filter by assignee |
 | `--tag` | `-T` | | Filter by tag |
 
+### Query tickets (JSONL)
+
+```bash
+todo query
+# {"id":"aBc","title":"Fix login timeout","priority":2,"deps":[],"links":[],"tags":[]}
+# {"id":"xYz","title":"Refactor auth","status":"in_progress","type":"bug","priority":1,"assignee":"Alice","deps":["aBc"],"links":[],"tags":["auth","urgent"]}
+```
+
+Outputs all tickets as JSON Lines (one JSON object per line) with all frontmatter fields. Useful for scripting, external tooling, and data analysis with `jq`:
+
+```bash
+# Count open tickets
+todo query --status open | wc -l
+
+# Get all high-priority tickets
+todo query | jq -r 'select(.priority <= 1) | .title'
+
+# Export to a file
+todo query > tickets.jsonl
+```
+
+Fields `id`, `title`, and `priority` are always present. String fields are omitted when empty. Array fields (`deps`, `links`, `tags`) are always present as arrays (never `null`).
+
+Filter by status, type, assignee, or tag:
+
+```bash
+# Filter by status
+todo query --status open
+
+# Filter by type
+todo query --type bug
+
+# Filter by assignee
+todo query -a Alice
+
+# Filter by tag
+todo query -T urgent
+
+# Combine filters (AND logic)
+todo query --status open --type bug -a Alice
+```
+
+**Flags:**
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--status` | | Filter by status: `open`, `in_progress`, `closed` |
+| `--type` | | Filter by type: `bug`, `feature`, `task`, `epic`, `chore` |
+| `--assignee` | `-a` | Filter by assignee |
+| `--tag` | `-T` | Filter by tag |
+
 ### Add notes
 
 ```bash

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -1,0 +1,140 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/juanibiapina/todo/internal/tickets"
+	"github.com/spf13/cobra"
+)
+
+// queryTicket is a JSON-serializable representation of a ticket.
+// Slices are always present as arrays (never null).
+type queryTicket struct {
+	ID          string   `json:"id"`
+	Title       string   `json:"title"`
+	Status      string   `json:"status,omitempty"`
+	Type        string   `json:"type,omitempty"`
+	Priority    int      `json:"priority"`
+	Assignee    string   `json:"assignee,omitempty"`
+	Created     string   `json:"created,omitempty"`
+	Parent      string   `json:"parent,omitempty"`
+	ExternalRef string   `json:"external_ref,omitempty"`
+	Design      string   `json:"design,omitempty"`
+	Acceptance  string   `json:"acceptance,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Deps        []string `json:"deps"`
+	Links       []string `json:"links"`
+	Tags        []string `json:"tags"`
+}
+
+func toQueryTicket(t *tickets.Ticket) queryTicket {
+	q := queryTicket{
+		ID:          t.ID,
+		Title:       t.Title,
+		Status:      t.Status,
+		Type:        t.Type,
+		Priority:    t.Priority,
+		Assignee:    t.Assignee,
+		Created:     t.Created,
+		Parent:      t.Parent,
+		ExternalRef: t.ExternalRef,
+		Design:      t.Design,
+		Acceptance:  t.Acceptance,
+		Description: t.Description,
+		Deps:        t.Deps,
+		Links:       t.Links,
+		Tags:        t.Tags,
+	}
+
+	// Ensure slices are never null in JSON output
+	if q.Deps == nil {
+		q.Deps = []string{}
+	}
+	if q.Links == nil {
+		q.Links = []string{}
+	}
+	if q.Tags == nil {
+		q.Tags = []string{}
+	}
+
+	return q
+}
+
+var queryCmd = &cobra.Command{
+	Use:   "query",
+	Short: "Output tickets as JSONL",
+	Long:  `Output all tickets as JSON Lines (one JSON object per line) with all frontmatter fields. Supports filtering by status, type, assignee, and tag.`,
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		allItems, err := tickets.List(dir)
+		if err != nil {
+			return err
+		}
+
+		statusFilter, _ := cmd.Flags().GetString("status")
+		typeFilter, _ := cmd.Flags().GetString("type")
+		assigneeFilter, _ := cmd.Flags().GetString("assignee")
+		tagFilter, _ := cmd.Flags().GetString("tag")
+
+		for _, t := range allItems {
+			// Apply --status filter
+			if statusFilter != "" {
+				if statusFilter == "open" {
+					if t.Status != "" && t.Status != "open" {
+						continue
+					}
+				} else if t.Status != statusFilter {
+					continue
+				}
+			}
+
+			// Apply --type filter
+			if typeFilter != "" && t.Type != typeFilter {
+				continue
+			}
+
+			// Apply --assignee filter
+			if assigneeFilter != "" && t.Assignee != assigneeFilter {
+				continue
+			}
+
+			// Apply --tag filter
+			if tagFilter != "" {
+				found := false
+				for _, tag := range t.Tags {
+					if tag == tagFilter {
+						found = true
+						break
+					}
+				}
+				if !found {
+					continue
+				}
+			}
+
+			q := toQueryTicket(t)
+			jsonBytes, err := json.Marshal(q)
+			if err != nil {
+				return fmt.Errorf("failed to marshal ticket %s: %w", t.ID, err)
+			}
+			fmt.Println(string(jsonBytes))
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	queryCmd.Flags().String("status", "", "Filter by status (open, in_progress, closed)")
+	queryCmd.Flags().String("type", "", "Filter by type (bug, feature, task, epic, chore)")
+	queryCmd.Flags().StringP("assignee", "a", "", "Filter by assignee")
+	queryCmd.Flags().StringP("tag", "T", "", "Filter by tag")
+	rootCmd.AddCommand(queryCmd)
+}

--- a/test/query.bats
+++ b/test/query.bats
@@ -1,0 +1,223 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "query: empty output when no tickets" {
+  run todo query
+  assert_success
+  assert_output ""
+}
+
+@test "query: outputs valid JSONL" {
+  run todo add "First ticket"
+  assert_success
+  run todo add "Second ticket"
+  assert_success
+
+  run todo query
+  assert_success
+
+  # Each line must be valid JSON
+  local line_count=0
+  while IFS= read -r line; do
+    echo "${line}" | jq . > /dev/null 2>&1
+    [ $? -eq 0 ]
+    line_count=$((line_count + 1))
+  done <<< "${output}"
+  [ "${line_count}" -eq 2 ]
+}
+
+@test "query: includes id, title, and priority fields" {
+  run todo add "My ticket"
+  assert_success
+  local id
+  id=$(extract_id_from_add "${output}")
+
+  run todo query
+  assert_success
+
+  local tid title priority
+  tid=$(echo "${output}" | jq -r '.id')
+  title=$(echo "${output}" | jq -r '.title')
+  priority=$(echo "${output}" | jq -r '.priority')
+
+  [ "${tid}" = "${id}" ]
+  [ "${title}" = "My ticket" ]
+  [ "${priority}" = "2" ]
+}
+
+@test "query: includes all frontmatter fields" {
+  run todo add "Full ticket" -t bug -p 1 -a Alice --external-ref "EXT-1" --design "Design doc" --acceptance "AC list" --tags "urgent,backend"
+  assert_success
+  local id
+  id=$(extract_id_from_add "${output}")
+
+  run todo start "${id}"
+  assert_success
+
+  run todo query
+  assert_success
+
+  [ "$(echo "${output}" | jq -r '.id')" = "${id}" ]
+  [ "$(echo "${output}" | jq -r '.title')" = "Full ticket" ]
+  [ "$(echo "${output}" | jq -r '.status')" = "in_progress" ]
+  [ "$(echo "${output}" | jq -r '.type')" = "bug" ]
+  [ "$(echo "${output}" | jq -r '.priority')" = "1" ]
+  [ "$(echo "${output}" | jq -r '.assignee')" = "Alice" ]
+  [ "$(echo "${output}" | jq -r '.external_ref')" = "EXT-1" ]
+  [ "$(echo "${output}" | jq -r '.design')" = "Design doc" ]
+  [ "$(echo "${output}" | jq -r '.acceptance')" = "AC list" ]
+  [ "$(echo "${output}" | jq -r '.tags | length')" = "2" ]
+  [ "$(echo "${output}" | jq -r '.tags[0]')" = "urgent" ]
+  [ "$(echo "${output}" | jq -r '.tags[1]')" = "backend" ]
+}
+
+@test "query: slices are arrays not null when empty" {
+  run todo add "Simple ticket"
+  assert_success
+
+  run todo query
+  assert_success
+
+  [ "$(echo "${output}" | jq -r '.deps | type')" = "array" ]
+  [ "$(echo "${output}" | jq -r '.links | type')" = "array" ]
+  [ "$(echo "${output}" | jq -r '.tags | type')" = "array" ]
+  [ "$(echo "${output}" | jq -r '.deps | length')" = "0" ]
+  [ "$(echo "${output}" | jq -r '.links | length')" = "0" ]
+  [ "$(echo "${output}" | jq -r '.tags | length')" = "0" ]
+}
+
+@test "query: includes deps and links" {
+  run todo add "Ticket A"
+  assert_success
+  local id_a
+  id_a=$(extract_id_from_add "${output}")
+
+  run todo add "Ticket B"
+  assert_success
+  local id_b
+  id_b=$(extract_id_from_add "${output}")
+
+  run todo dep "${id_a}" "${id_b}"
+  assert_success
+
+  run todo link "${id_a}" "${id_b}"
+  assert_success
+
+  # Query and check ticket A
+  run todo query
+  assert_success
+
+  local a_line
+  a_line=$(echo "${output}" | jq -r "select(.id == \"${id_a}\")")
+
+  [ "$(echo "${a_line}" | jq -r '.deps | length')" = "1" ]
+  [ "$(echo "${a_line}" | jq -r '.deps[0]')" = "${id_b}" ]
+  [ "$(echo "${a_line}" | jq -r '.links | length')" = "1" ]
+  [ "$(echo "${a_line}" | jq -r '.links[0]')" = "${id_b}" ]
+}
+
+@test "query: --status filter" {
+  run todo add "Open ticket"
+  assert_success
+
+  run todo add "Closed ticket"
+  assert_success
+  local closed_id
+  closed_id=$(extract_id_from_add "${output}")
+  run todo done "${closed_id}"
+  assert_success
+
+  run todo query --status closed
+  assert_success
+
+  local count
+  count=$(echo "${output}" | wc -l | tr -d ' ')
+  [ "${count}" -eq 1 ]
+  [ "$(echo "${output}" | jq -r '.title')" = "Closed ticket" ]
+}
+
+@test "query: --status open matches empty status" {
+  run todo add "New ticket"
+  assert_success
+
+  run todo query --status open
+  assert_success
+
+  local count
+  count=$(echo "${output}" | wc -l | tr -d ' ')
+  [ "${count}" -eq 1 ]
+  [ "$(echo "${output}" | jq -r '.title')" = "New ticket" ]
+}
+
+@test "query: --type filter" {
+  run todo add "Bug ticket" -t bug
+  assert_success
+  run todo add "Feature ticket" -t feature
+  assert_success
+
+  run todo query --type bug
+  assert_success
+
+  local count
+  count=$(echo "${output}" | wc -l | tr -d ' ')
+  [ "${count}" -eq 1 ]
+  [ "$(echo "${output}" | jq -r '.title')" = "Bug ticket" ]
+}
+
+@test "query: --assignee filter" {
+  run todo add "Alice ticket" -a Alice
+  assert_success
+  run todo add "Bob ticket" -a Bob
+  assert_success
+
+  run todo query --assignee Alice
+  assert_success
+
+  local count
+  count=$(echo "${output}" | wc -l | tr -d ' ')
+  [ "${count}" -eq 1 ]
+  [ "$(echo "${output}" | jq -r '.title')" = "Alice ticket" ]
+}
+
+@test "query: --tag filter" {
+  run todo add "Tagged ticket" --tags "urgent,backend"
+  assert_success
+  run todo add "Other ticket" --tags "frontend"
+  assert_success
+
+  run todo query --tag urgent
+  assert_success
+
+  local count
+  count=$(echo "${output}" | wc -l | tr -d ' ')
+  [ "${count}" -eq 1 ]
+  [ "$(echo "${output}" | jq -r '.title')" = "Tagged ticket" ]
+}
+
+@test "query: combined filters" {
+  run todo add "Match ticket" -t bug -a Alice --tags "urgent"
+  assert_success
+  run todo add "Wrong type" -t feature -a Alice --tags "urgent"
+  assert_success
+  run todo add "Wrong assignee" -t bug -a Bob --tags "urgent"
+  assert_success
+
+  run todo query --type bug --assignee Alice --tag urgent
+  assert_success
+
+  local count
+  count=$(echo "${output}" | wc -l | tr -d ' ')
+  [ "${count}" -eq 1 ]
+  [ "$(echo "${output}" | jq -r '.title')" = "Match ticket" ]
+}
+
+@test "query: includes description" {
+  run todo add "With desc" -d "Some description text"
+  assert_success
+
+  run todo query
+  assert_success
+
+  [ "$(echo "${output}" | jq -r '.description')" = "Some description text" ]
+}


### PR DESCRIPTION
Adds a `todo query` command that outputs tickets as JSONL (one JSON object per line) with filter support, enabling scripting and integration with tools like `jq`.

- **`cmd/query.go`**: New Cobra command with `queryTicket` struct for JSON serialization. `id`, `title`, `priority` always present; string fields use `omitempty`; array fields (`deps`, `links`, `tags`) always serialize as `[]` (never `null`). Filters: `--status`, `--type`, `-a/--assignee`, `-T/--tag` with AND logic. `--status open` matches both empty and `"open"` status.
- **`test/query.bats`**: 13 integration tests covering: empty output, valid JSONL, field presence, all frontmatter fields, arrays-not-null, deps/links, status/type/assignee/tag filters, combined filters, description field. Uses `jq` for JSON assertions.
- **`README.md`**: Added "Query tickets (JSONL)" section with usage examples (`jq` integration, file export, counting), field presence rules, filter examples, and flags reference table.
- **`CHANGELOG.md`**: Added entry under `[Unreleased] > Added`.

All 93 unit tests and 211 bats integration tests pass.
