### PR TITLE
Add progress counter to TUI title

### DIFF
--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -212,6 +212,15 @@ func (m Model) View() string {
 	var b strings.Builder
 
 	b.WriteString(titleStyle.Render("Todo"))
+	if total := len(m.items); total > 0 {
+		checked := 0
+		for _, item := range m.items {
+			if item.Checked {
+				checked++
+			}
+		}
+		b.WriteString(helpStyle.Render(fmt.Sprintf(" %d/%d", checked, total)))
+	}
 	b.WriteString("\n\n")
 
 	if len(m.items) == 0 && m.mode != modeAdd {


### PR DESCRIPTION
Adds a checked/total progress counter to the TUI title line (e.g. `Todo 2/5`).

**What changed:**
- In `internal/tui/tui.go`, the `View()` method now computes the number of checked items from `m.items` and renders the count next to the title using `helpStyle` (dim gray).
- The counter only appears when there are items (hidden on empty lists).
- No new dependencies or store changes needed.

All tests pass (`go test` + 38 bats integration tests).