### PR TITLE
Add --all flag to list todos across directories

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -9,22 +9,56 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var listAll bool
+
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List todo items",
-	Long:  `List all todo items for the current directory.`,
+	Long:  `List all todo items for the current directory, or all directories with --all.`,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		dir, err := os.Getwd()
-		if err != nil {
-			return err
-		}
-
 		s, err := store.Open(config.DefaultFilePath())
 		if err != nil {
 			return err
 		}
 		defer s.Close()
+
+		if listAll {
+			items, err := s.ListAll()
+			if err != nil {
+				return err
+			}
+
+			currentDir := ""
+			for _, item := range items {
+				if item.Directory != currentDir {
+					if currentDir != "" {
+						fmt.Println()
+					}
+					fmt.Printf("%s\n", item.Directory)
+					currentDir = item.Directory
+				}
+				if item.IsSection {
+					fmt.Println("  ──────────")
+					continue
+				}
+				check := " "
+				if item.Checked {
+					check = "x"
+				}
+				active := ""
+				if item.IsActive {
+					active = "  (active)"
+				}
+				fmt.Printf("  %d [%s] %s%s\n", item.ID, check, item.Text, active)
+			}
+			return nil
+		}
+
+		dir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
 
 		if err := s.CleanIfNewDay(dir); err != nil {
 			return err
@@ -56,5 +90,6 @@ var listCmd = &cobra.Command{
 }
 
 func init() {
+	listCmd.Flags().BoolVarP(&listAll, "all", "a", false, "List items from all directories")
 	rootCmd.AddCommand(listCmd)
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -180,6 +180,39 @@ func (s *Store) List(directory string) ([]*Item, error) {
 	return items, nil
 }
 
+// ListAll returns all items across every directory in the file, preserving
+// per-directory ordering (active first, then by position within each directory).
+func (s *Store) ListAll() ([]*Item, error) {
+	data, err := s.readFile()
+	if err != nil {
+		return nil, err
+	}
+
+	var all []*Item
+	for _, dir := range data.directories {
+		items := make([]*Item, len(dir.items))
+		for i, fi := range dir.items {
+			items[i] = &Item{
+				ID:        i + 1,
+				Directory: dir.path,
+				Text:      fi.text,
+				Checked:   fi.checked,
+				IsSection: fi.isSection,
+				IsActive:  fi.isActive,
+			}
+		}
+		sort.SliceStable(items, func(i, j int) bool {
+			if items[i].IsActive != items[j].IsActive {
+				return items[i].IsActive
+			}
+			return items[i].ID < items[j].ID
+		})
+		all = append(all, items...)
+	}
+
+	return all, nil
+}
+
 // Get returns a single item by position (1-based) within the directory.
 func (s *Store) Get(directory string, id int) (*Item, error) {
 	data, err := s.readFile()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -114,6 +114,76 @@ func TestListIsolatesByDirectory(t *testing.T) {
 	}
 }
 
+func TestListAllEmpty(t *testing.T) {
+	s := openTestStore(t)
+
+	items, err := s.ListAll()
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+	if len(items) != 0 {
+		t.Errorf("expected 0 items, got %d", len(items))
+	}
+}
+
+func TestListAllReturnsItemsFromAllDirectories(t *testing.T) {
+	s := openTestStore(t)
+
+	s.Add("/dir-a", "Task A1")
+	s.Add("/dir-a", "Task A2")
+	s.Add("/dir-b", "Task B1")
+
+	items, err := s.ListAll()
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+	if len(items) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(items))
+	}
+}
+
+func TestListAllPreservesDirectoryField(t *testing.T) {
+	s := openTestStore(t)
+
+	s.Add("/dir-a", "Task A")
+	s.Add("/dir-b", "Task B")
+
+	items, err := s.ListAll()
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+
+	dirs := map[string]bool{}
+	for _, item := range items {
+		dirs[item.Directory] = true
+	}
+	if !dirs["/dir-a"] {
+		t.Error("expected /dir-a in results")
+	}
+	if !dirs["/dir-b"] {
+		t.Error("expected /dir-b in results")
+	}
+}
+
+func TestListAllActiveItemsFirstWithinDirectory(t *testing.T) {
+	s := openTestStore(t)
+
+	s.Add("/d", "Normal")
+	active, _ := s.Add("/d", "Active")
+	s.ToggleActive("/d", active.ID)
+
+	items, err := s.ListAll()
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	if !items[0].IsActive {
+		t.Errorf("expected active item first, got %q", items[0].Text)
+	}
+}
+
 func TestCheck(t *testing.T) {
 	s := openTestStore(t)
 


### PR DESCRIPTION
Adds todo list --all to show todo items from every directory stored in the Markdown file.
