### PR TITLE
Add Dependabot for automatic dependency upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      production:
+        dependency-type: production
+      development:
+        dependency-type: development
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Adds Dependabot configuration for automated dependency updates.

**Ecosystems configured:**
- `gomod` (weekly, grouped by production/development)
- `github-actions` (weekly)

Dependabot will open PRs for outdated dependencies on a weekly schedule. Dependencies are grouped to reduce PR noise.